### PR TITLE
fix: properly tear down MQTT on reconnect, do status check on reconnect

### DIFF
--- a/src/emerald_hws/emeraldhws.py
+++ b/src/emerald_hws/emeraldhws.py
@@ -891,7 +891,7 @@ class EmeraldHWS:
             self.health_check_timer.cancel()
             self.health_check_timer = None
 
-        # Stop MQTT client
+        # Stop MQTT client and reset connection state atomically
         with self._mqtt_lock:
             if self.mqttClient is not None:
                 try:
@@ -908,5 +908,5 @@ class EmeraldHWS:
                 finally:
                     self.mqttClient = None
 
-        self._is_connected = False
-        self._connection_event.clear()
+            self._is_connected = False
+            self._connection_event.clear()

--- a/src/emerald_hws/emeraldhws.py
+++ b/src/emerald_hws/emeraldhws.py
@@ -219,6 +219,17 @@ class EmeraldHWS:
                 f"emeraldhws: awsiot: MQTT reconnection completed (reason: {reason})"
             )
 
+        # Refresh state from API outside the mqtt_lock to avoid holding it during HTTP calls
+        try:
+            self.getAllHWS()
+            self.logger.debug(
+                "emeraldhws: awsiot: State refreshed from API after reconnect"
+            )
+        except Exception as e:
+            self.logger.warning(
+                f"emeraldhws: awsiot: Failed to refresh state during reconnect: {e}"
+            )
+
     def connectMQTT(self):
         """Establishes a connection to Amazon IOT core's MQTT service"""
         with self._mqtt_lock:
@@ -864,3 +875,38 @@ class EmeraldHWS:
                 )
                 self.health_check_timer.daemon = True
                 self.health_check_timer.start()
+
+    def disconnect(self):
+        """Disconnect MQTT client and cancel all background timers.
+        Should be called when the integration is being unloaded to prevent
+        zombie MQTT sessions from accumulating.
+        """
+        self.logger.info("emeraldhws: Disconnecting and cleaning up")
+
+        # Cancel timers first to prevent them from triggering reconnects
+        if self.reconnect_timer:
+            self.reconnect_timer.cancel()
+            self.reconnect_timer = None
+        if self.health_check_timer:
+            self.health_check_timer.cancel()
+            self.health_check_timer = None
+
+        # Stop MQTT client
+        with self._mqtt_lock:
+            if self.mqttClient is not None:
+                try:
+                    stop_future = self.mqttClient.stop()
+                    if stop_future:
+                        stop_future.result(timeout=10)
+                    self.logger.debug(
+                        "emeraldhws: MQTT client stopped successfully during disconnect"
+                    )
+                except Exception as e:
+                    self.logger.warning(
+                        f"emeraldhws: Error stopping MQTT client during disconnect: {e}"
+                    )
+                finally:
+                    self.mqttClient = None
+
+        self._is_connected = False
+        self._connection_event.clear()

--- a/tests/test_reconnection_behaviour.py
+++ b/tests/test_reconnection_behaviour.py
@@ -91,8 +91,36 @@ def test_state_refresh_failure_during_reconnection_is_non_fatal(
     # Reconnect should not raise even if getAllHWS fails
     client.reconnectMQTT()
 
-    # MQTT client should still be set up
+    # MQTT client should still be set up and connection healthy
     assert client.mqttClient is not None
+    assert client._is_connected is True
+
+
+def test_state_refresh_exception_during_reconnection_is_non_fatal(
+    mock_requests, mock_boto3, mock_mqtt5_client_builder, mock_auth, mock_io, mocker
+):
+    """Test that reconnect survives when getAllHWS raises an exception."""
+    mock_login = Mock()
+    mock_login.json.return_value = MOCK_LOGIN_RESPONSE
+    mock_requests.post.return_value = mock_login
+
+    mock_properties = Mock()
+    mock_properties.json.return_value = MOCK_PROPERTY_RESPONSE_SELF
+    mock_requests.get.return_value = mock_properties
+
+    client = EmeraldHWS("test@example.com", "password")
+    mocker.patch.object(client._connection_event, "wait", return_value=True)
+    client.connect()
+
+    # Make getAllHWS raise an exception on reconnect (simulating network failure)
+    mock_requests.get.side_effect = Exception("Connection timed out")
+
+    # Reconnect should not raise
+    client.reconnectMQTT()
+
+    # MQTT client should still be set up and connection healthy
+    assert client.mqttClient is not None
+    assert client._is_connected is True
 
 
 def test_mqtt_subscriptions_after_reconnection(
@@ -154,8 +182,14 @@ def test_disconnect_stops_mqtt_and_cancels_timers(
     assert client.reconnect_timer is not None
     assert client.health_check_timer is not None
 
+    # Capture MQTT client reference before disconnect clears it
+    mqtt_client = client.mqttClient
+
     # Disconnect
     client.disconnect()
+
+    # Verify stop() was called on the underlying MQTT client
+    mqtt_client.stop.assert_called_once()
 
     # Verify everything is cleaned up
     assert client.mqttClient is None

--- a/tests/test_reconnection_behaviour.py
+++ b/tests/test_reconnection_behaviour.py
@@ -1,6 +1,5 @@
 """Tests for reconnection behaviour and state persistence."""
 
-import copy
 from unittest.mock import Mock
 from emerald_hws import EmeraldHWS
 from .conftest import (
@@ -37,10 +36,14 @@ def test_auto_connection_on_operation_when_disconnected(
     assert mock_mqtt5_client_builder.websockets_with_default_aws_signing.called
 
 
-def test_state_preservation_during_reconnection(
+def test_state_refreshed_from_api_during_reconnection(
     mock_requests, mock_boto3, mock_mqtt5_client_builder, mock_auth, mock_io, mocker
 ):
-    """Test that manually set state is preserved during reconnection."""
+    """Test that getAllHWS is called during reconnection to refresh state.
+
+    When reconnecting, getAllHWS() is called to get fresh state from the API.
+    This prevents state drift when MQTT messages are missed during disconnection.
+    """
     mock_login = Mock()
     mock_login.json.return_value = MOCK_LOGIN_RESPONSE
     mock_requests.post.return_value = mock_login
@@ -54,26 +57,42 @@ def test_state_preservation_during_reconnection(
     mocker.patch.object(client._connection_event, "wait", return_value=True)
     client.connect()
 
-    hws_id = "hws-1111-aaaa-2222-bbbb"
+    # Record how many times the API was called during initial connect
+    get_call_count_after_connect = mock_requests.get.call_count
 
-    # Manually set some state (simulating previous MQTT updates)
-    client.properties = copy.deepcopy(MOCK_PROPERTY_RESPONSE_SELF["info"]["property"])
-    client.properties[0]["heat_pump"][0]["last_state"]["temp_current"] = 65
-    client.properties[0]["heat_pump"][0]["last_state"]["switch"] = 1
-    client.properties[0]["heat_pump"][0]["last_state"]["mode"] = 2
-
-    # Verify state is set
-    assert client.properties[0]["heat_pump"][0]["last_state"]["temp_current"] == 65
-    assert client.isOn(hws_id) is True
-    assert client.currentMode(hws_id) == 2
-
-    # Reconnect
+    # Reconnect — should call getAllHWS which triggers another GET request
     client.reconnectMQTT()
 
-    # Verify state is preserved
-    assert client.properties[0]["heat_pump"][0]["last_state"]["temp_current"] == 65
-    assert client.isOn(hws_id) is True
-    assert client.currentMode(hws_id) == 2
+    # Verify getAllHWS was called during reconnect (GET call count increased)
+    assert mock_requests.get.call_count > get_call_count_after_connect
+
+
+def test_state_refresh_failure_during_reconnection_is_non_fatal(
+    mock_requests, mock_boto3, mock_mqtt5_client_builder, mock_auth, mock_io, mocker
+):
+    """Test that a failed API refresh during reconnect doesn't break the connection."""
+    mock_login = Mock()
+    mock_login.json.return_value = MOCK_LOGIN_RESPONSE
+    mock_requests.post.return_value = mock_login
+
+    mock_properties = Mock()
+    mock_properties.json.return_value = MOCK_PROPERTY_RESPONSE_SELF
+    mock_requests.get.return_value = mock_properties
+
+    client = EmeraldHWS("test@example.com", "password")
+    mocker.patch.object(client._connection_event, "wait", return_value=True)
+    client.connect()
+
+    # Make getAllHWS fail on reconnect
+    mock_properties_fail = Mock()
+    mock_properties_fail.json.return_value = {"code": 500}
+    mock_requests.get.return_value = mock_properties_fail
+
+    # Reconnect should not raise even if getAllHWS fails
+    client.reconnectMQTT()
+
+    # MQTT client should still be set up
+    assert client.mqttClient is not None
 
 
 def test_mqtt_subscriptions_after_reconnection(
@@ -111,3 +130,48 @@ def test_mqtt_subscriptions_after_reconnection(
 
     # Verify subscription was called again
     assert len(subscribe_calls) > initial_subscribe_count
+
+
+def test_disconnect_stops_mqtt_and_cancels_timers(
+    mock_requests, mock_boto3, mock_mqtt5_client_builder, mock_auth, mock_io, mocker
+):
+    """Test that disconnect() stops the MQTT client and cancels all timers."""
+    mock_login = Mock()
+    mock_login.json.return_value = MOCK_LOGIN_RESPONSE
+    mock_requests.post.return_value = mock_login
+
+    mock_properties = Mock()
+    mock_properties.json.return_value = MOCK_PROPERTY_RESPONSE_SELF
+    mock_requests.get.return_value = mock_properties
+
+    client = EmeraldHWS("test@example.com", "password")
+    mocker.patch.object(client._connection_event, "wait", return_value=True)
+    client.connect()
+
+    # Verify timers and client are active after connect
+    assert client.mqttClient is not None
+    assert client._is_connected is True
+    assert client.reconnect_timer is not None
+    assert client.health_check_timer is not None
+
+    # Disconnect
+    client.disconnect()
+
+    # Verify everything is cleaned up
+    assert client.mqttClient is None
+    assert client._is_connected is False
+    assert client.reconnect_timer is None
+    assert client.health_check_timer is None
+
+
+def test_disconnect_handles_missing_client_gracefully(
+    mock_requests, mock_boto3, mock_mqtt5_client_builder, mock_auth, mock_io, mocker
+):
+    """Test that disconnect() works even if MQTT client is already None."""
+    client = EmeraldHWS("test@example.com", "password")
+
+    # Should not raise even when nothing is connected
+    client.disconnect()
+
+    assert client.mqttClient is None
+    assert client._is_connected is False


### PR DESCRIPTION
## Summary by Sourcery

Ensure MQTT reconnection refreshes device state from the API and add a robust disconnect path that fully tears down MQTT and timers.

New Features:
- Refresh device state from the API after successful MQTT reconnection.
- Provide a disconnect() API that stops the MQTT client, cancels background timers, and resets connection state.

Bug Fixes:
- Prevent state drift after reconnection by fetching fresh device state instead of relying on stale in-memory data.
- Handle API failures and exceptions during state refresh on reconnect without breaking the MQTT connection.
- Ensure disconnect() behaves safely when no MQTT client is currently instantiated.

Tests:
- Extend reconnection tests to assert state refresh from the API and resilience to API failures during reconnect.
- Add tests verifying that disconnect() stops the MQTT client, cancels timers, and handles a missing client gracefully.