### PR TITLE
fix: regression with lifecycle handling since 1.0.3

### DIFF
--- a/src/emerald_hws/emeraldhws.py
+++ b/src/emerald_hws/emeraldhws.py
@@ -219,15 +219,12 @@ class EmeraldHWS:
                 f"emeraldhws: awsiot: MQTT reconnection completed (reason: {reason})"
             )
 
-        # Refresh state from API outside the mqtt_lock to avoid holding it during HTTP calls
+        # Request fresh status from all HWS via MQTT (like the official app does)
         try:
-            self.getAllHWS()
-            self.logger.debug(
-                "emeraldhws: awsiot: State refreshed from API after reconnect"
-            )
+            self.requestAllStatusUpdates()
         except Exception as e:
             self.logger.warning(
-                f"emeraldhws: awsiot: Failed to refresh state during reconnect: {e}"
+                f"emeraldhws: awsiot: Failed to request status updates after reconnect: {e}"
             )
 
     def connectMQTT(self):
@@ -300,7 +297,7 @@ class EmeraldHWS:
 
         command = json_payload[0].get("command")
         if command is not None:
-            if command == "upload_status":
+            if command == "upload_status" or command == "comp_query":
                 for key in json_payload[1]:
                     self.updateHWSState(hws_id, key, json_payload[1][key])
             elif command == "update_hour_energy":
@@ -327,12 +324,20 @@ class EmeraldHWS:
         )
 
     def on_connection_resumed(self, connection, return_code, session_present, **kwargs):
-        """Log message when MQTT is resumed"""
-        self.logger.debug(
+        """Log message when MQTT is resumed and request fresh status from all HWS"""
+        self.logger.info(
             "emeraldhws: awsiot: Connection resumed. return_code: {} session_present: {}".format(
                 return_code, session_present
             )
         )
+        # Request fresh status from all HWS after the SDK auto-reconnects.
+        # The comp_query responses will naturally update last_message_time via mqttCallback.
+        try:
+            self.requestAllStatusUpdates()
+        except Exception as e:
+            self.logger.warning(
+                f"emeraldhws: awsiot: Failed to request status updates after connection resume: {e}"
+            )
 
     def on_lifecycle_connection_success(
         self, lifecycle_connect_success_data: mqtt5.LifecycleConnectSuccessData
@@ -448,9 +453,11 @@ class EmeraldHWS:
 
         self.logger.info(f"emeraldhws: awsiot: disconnected - {reason}")
 
-        # Clear connection event when disconnected
+        # Do NOT set _is_connected = False here. The AWS IoT SDK handles
+        # transient disconnections automatically (interrupt → auto-reconnect → resume).
+        # Setting _is_connected = False would cause getFullStatus/sendControlMessage
+        # to call connect(), creating a competing MQTT connection and duplicate timers.
         self._connection_event.clear()
-        self._is_connected = False
         return
 
     def on_lifecycle_attempting_connect(
@@ -492,16 +499,22 @@ class EmeraldHWS:
                     f"emeraldhws: awsiot: No messages received for {minutes_since_last:.1f} minutes, reconnecting"
                 )
 
-                # If we're in a failed state, apply exponential backoff
+                # If we're in a failed state, apply exponential backoff by delaying the next check
                 if self.connection_state == "failed" and self.consecutive_failures > 0:
-                    # Calculate backoff time with exponential increase, capped at max_backoff_seconds
                     backoff_seconds = min(
                         2 ** (self.consecutive_failures - 1), self.max_backoff_seconds
                     )
                     self.logger.info(
-                        f"emeraldhws: awsiot: Connection in failed state, applying backoff of {backoff_seconds} seconds before retry (attempt {self.consecutive_failures})"
+                        f"emeraldhws: awsiot: Connection in failed state, delaying next health check by {backoff_seconds} seconds (attempt {self.consecutive_failures})"
                     )
-                    time.sleep(backoff_seconds)
+                    # Reschedule with backoff instead of blocking the timer thread
+                    if self.health_check_interval > 0:
+                        self.health_check_timer = threading.Timer(
+                            backoff_seconds, self.check_connection_health
+                        )
+                        self.health_check_timer.daemon = True
+                        self.health_check_timer.start()
+                    return
 
                 self.reconnectMQTT(reason="health_check")
             else:
@@ -843,6 +856,55 @@ class EmeraldHWS:
             for hws in property.get("heat_pump"):
                 self.subscribeForUpdates(hws.get("id"))
 
+    def requestStatusUpdate(self, id):
+        """Sends a comp_query MQTT message to request the HWS to report its full current status.
+        This is what the official Emerald app does to get an immediate status update.
+        :param id: The UUID of the requested HWS
+        """
+        hwsdetail = self.getFullStatus(id)
+        if not hwsdetail:
+            raise Exception(f"Unable to find HWS with ID {id}")
+
+        msg = [
+            {
+                "msg_id": "{}".format(random.randint(100, 9999)),
+                "namespace": "business",
+                "direction": "app2gw",
+                "command": "comp_query",
+                "property_id": hwsdetail.get("property_id"),
+                "device_id": id,
+                "hw_id": hwsdetail.get("mac_address"),
+            },
+            {},
+        ]
+        mqtt_topic = "ep/heat_pump/to_gw/{}".format(id)
+
+        with self._mqtt_lock:
+            if not self.mqttClient:
+                raise Exception("MQTT client not connected")
+            publish_future = self.mqttClient.publish(
+                mqtt5.PublishPacket(
+                    topic=mqtt_topic,
+                    payload=json.dumps(msg),
+                    qos=mqtt5.QoS.AT_LEAST_ONCE,
+                )
+            )
+
+        publish_future.result(20)
+        self.logger.debug(f"emeraldhws: Sent comp_query to HWS {id}")
+
+    def requestAllStatusUpdates(self):
+        """Requests a status update from all known HWS via MQTT comp_query"""
+        properties_list = self._wait_for_properties()
+        for properties in properties_list:
+            for hws in properties.get("heat_pump", []):
+                try:
+                    self.requestStatusUpdate(hws.get("id"))
+                except Exception as e:
+                    self.logger.warning(
+                        f"emeraldhws: Failed to request status update for HWS {hws.get('id')}: {e}"
+                    )
+
     def connect(self):
         """Connect to the API with the supplied credentials, retrieve HWS details
         :returns: True if successful
@@ -861,7 +923,12 @@ class EmeraldHWS:
             self.subscribeAllHWS()
             self._is_connected = True
 
-            # Start timers ONCE on initial connection
+            # Cancel any existing timers before starting new ones to prevent accumulation
+            if self.reconnect_timer:
+                self.reconnect_timer.cancel()
+            if self.health_check_timer:
+                self.health_check_timer.cancel()
+
             if self.connection_timeout > 0:
                 self.reconnect_timer = threading.Timer(
                     self.connection_timeout, self.scheduled_reconnect

--- a/src/emerald_hws/emeraldhws.py
+++ b/src/emerald_hws/emeraldhws.py
@@ -220,11 +220,15 @@ class EmeraldHWS:
             )
 
         # Request fresh status from all HWS via MQTT (like the official app does)
+        self._request_status_updates_safe()
+
+    def _request_status_updates_safe(self):
+        """Request status updates from all HWS, logging any failures."""
         try:
             self.requestAllStatusUpdates()
         except Exception as e:
             self.logger.warning(
-                f"emeraldhws: awsiot: Failed to request status updates after reconnect: {e}"
+                f"emeraldhws: awsiot: Failed to request status updates: {e}"
             )
 
     def connectMQTT(self):
@@ -330,14 +334,14 @@ class EmeraldHWS:
                 return_code, session_present
             )
         )
-        # Request fresh status from all HWS after the SDK auto-reconnects.
-        # The comp_query responses will naturally update last_message_time via mqttCallback.
-        try:
-            self.requestAllStatusUpdates()
-        except Exception as e:
-            self.logger.warning(
-                f"emeraldhws: awsiot: Failed to request status updates after connection resume: {e}"
-            )
+        # Request fresh status in a background thread so we don't block the
+        # AWS IoT MQTT callback thread / event loop with _wait_for_properties()
+        # and publish_future.result() calls.
+        threading.Thread(
+            target=self._request_status_updates_safe,
+            name="emeraldhws-status-refresh-on-resume",
+            daemon=True,
+        ).start()
 
     def on_lifecycle_connection_success(
         self, lifecycle_connect_success_data: mqtt5.LifecycleConnectSuccessData
@@ -894,15 +898,36 @@ class EmeraldHWS:
         self.logger.debug(f"emeraldhws: Sent comp_query to HWS {id}")
 
     def requestAllStatusUpdates(self):
-        """Requests a status update from all known HWS via MQTT comp_query"""
+        """Requests a status update from all known HWS via MQTT comp_query.
+
+        Uses a thread pool so that a slow or blocked publish for one device
+        doesn't delay queries to other devices (each can block up to 20s).
+        """
+        from concurrent.futures import ThreadPoolExecutor, as_completed
+
         properties_list = self._wait_for_properties()
+        hws_ids = []
         for properties in properties_list:
             for hws in properties.get("heat_pump", []):
+                hws_id = hws.get("id")
+                if hws_id is not None:
+                    hws_ids.append(hws_id)
+
+        if not hws_ids:
+            return
+
+        with ThreadPoolExecutor(max_workers=min(5, len(hws_ids))) as executor:
+            future_to_id = {
+                executor.submit(self.requestStatusUpdate, hws_id): hws_id
+                for hws_id in hws_ids
+            }
+            for future in as_completed(future_to_id):
+                hws_id = future_to_id[future]
                 try:
-                    self.requestStatusUpdate(hws.get("id"))
+                    future.result()
                 except Exception as e:
                     self.logger.warning(
-                        f"emeraldhws: Failed to request status update for HWS {hws.get('id')}: {e}"
+                        f"emeraldhws: Failed to request status update for HWS {hws_id}: {e}"
                     )
 
     def connect(self):

--- a/tests/test_reconnection_behaviour.py
+++ b/tests/test_reconnection_behaviour.py
@@ -36,13 +36,14 @@ def test_auto_connection_on_operation_when_disconnected(
     assert mock_mqtt5_client_builder.websockets_with_default_aws_signing.called
 
 
-def test_state_refreshed_from_api_during_reconnection(
+def test_status_requested_via_mqtt_during_reconnection(
     mock_requests, mock_boto3, mock_mqtt5_client_builder, mock_auth, mock_io, mocker
 ):
-    """Test that getAllHWS is called during reconnection to refresh state.
+    """Test that comp_query is sent via MQTT during reconnection to refresh state.
 
-    When reconnecting, getAllHWS() is called to get fresh state from the API.
-    This prevents state drift when MQTT messages are missed during disconnection.
+    When reconnecting, requestAllStatusUpdates() sends comp_query MQTT messages
+    to each HWS to trigger them to report their current status. This is what
+    the official Emerald app does and avoids replacing MQTT state with stale API data.
     """
     mock_login = Mock()
     mock_login.json.return_value = MOCK_LOGIN_RESPONSE
@@ -57,20 +58,24 @@ def test_state_refreshed_from_api_during_reconnection(
     mocker.patch.object(client._connection_event, "wait", return_value=True)
     client.connect()
 
-    # Record how many times the API was called during initial connect
-    get_call_count_after_connect = mock_requests.get.call_count
+    mqtt_client = (
+        mock_mqtt5_client_builder.websockets_with_default_aws_signing.return_value
+    )
 
-    # Reconnect — should call getAllHWS which triggers another GET request
+    # Record publish call count after initial connect
+    publish_count_after_connect = mqtt_client.publish.call_count
+
+    # Reconnect — should send comp_query via MQTT publish
     client.reconnectMQTT()
 
-    # Verify getAllHWS was called during reconnect (GET call count increased)
-    assert mock_requests.get.call_count > get_call_count_after_connect
+    # Verify MQTT publish was called during reconnect (for comp_query)
+    assert mqtt_client.publish.call_count > publish_count_after_connect
 
 
-def test_state_refresh_failure_during_reconnection_is_non_fatal(
+def test_status_request_failure_during_reconnection_is_non_fatal(
     mock_requests, mock_boto3, mock_mqtt5_client_builder, mock_auth, mock_io, mocker
 ):
-    """Test that a failed API refresh during reconnect doesn't break the connection."""
+    """Test that a failed MQTT status request during reconnect doesn't break the connection."""
     mock_login = Mock()
     mock_login.json.return_value = MOCK_LOGIN_RESPONSE
     mock_requests.post.return_value = mock_login
@@ -83,12 +88,15 @@ def test_state_refresh_failure_during_reconnection_is_non_fatal(
     mocker.patch.object(client._connection_event, "wait", return_value=True)
     client.connect()
 
-    # Make getAllHWS fail on reconnect
-    mock_properties_fail = Mock()
-    mock_properties_fail.json.return_value = {"code": 500}
-    mock_requests.get.return_value = mock_properties_fail
+    # Make MQTT publish fail on reconnect (simulating MQTT issues)
+    mqtt_client = (
+        mock_mqtt5_client_builder.websockets_with_default_aws_signing.return_value
+    )
+    mqtt_client.publish.return_value.result.side_effect = Exception(
+        "MQTT publish failed"
+    )
 
-    # Reconnect should not raise even if getAllHWS fails
+    # Reconnect should not raise even if status request fails
     client.reconnectMQTT()
 
     # MQTT client should still be set up and connection healthy
@@ -96,10 +104,10 @@ def test_state_refresh_failure_during_reconnection_is_non_fatal(
     assert client._is_connected is True
 
 
-def test_state_refresh_exception_during_reconnection_is_non_fatal(
+def test_status_request_exception_during_reconnection_is_non_fatal(
     mock_requests, mock_boto3, mock_mqtt5_client_builder, mock_auth, mock_io, mocker
 ):
-    """Test that reconnect survives when getAllHWS raises an exception."""
+    """Test that reconnect survives when requestAllStatusUpdates raises an exception."""
     mock_login = Mock()
     mock_login.json.return_value = MOCK_LOGIN_RESPONSE
     mock_requests.post.return_value = mock_login
@@ -112,8 +120,10 @@ def test_state_refresh_exception_during_reconnection_is_non_fatal(
     mocker.patch.object(client._connection_event, "wait", return_value=True)
     client.connect()
 
-    # Make getAllHWS raise an exception on reconnect (simulating network failure)
-    mock_requests.get.side_effect = Exception("Connection timed out")
+    # Make MQTT client None to simulate connection issue during status request
+    mocker.patch.object(
+        client, "requestAllStatusUpdates", side_effect=Exception("Connection lost")
+    )
 
     # Reconnect should not raise
     client.reconnectMQTT()

--- a/tests/test_reconnection_behaviour.py
+++ b/tests/test_reconnection_behaviour.py
@@ -1,5 +1,6 @@
 """Tests for reconnection behaviour and state persistence."""
 
+import json
 from unittest.mock import Mock
 from emerald_hws import EmeraldHWS
 from .conftest import (
@@ -70,6 +71,22 @@ def test_status_requested_via_mqtt_during_reconnection(
 
     # Verify MQTT publish was called during reconnect (for comp_query)
     assert mqtt_client.publish.call_count > publish_count_after_connect
+
+    # Verify the payload is a comp_query with correct device details
+    publish_calls_after = mqtt_client.publish.call_args_list[
+        publish_count_after_connect:
+    ]
+    assert len(publish_calls_after) >= 1
+
+    packet = publish_calls_after[0][0][0]  # first new call, positional arg
+    assert packet.topic == "ep/heat_pump/to_gw/hws-1111-aaaa-2222-bbbb"
+    payload = json.loads(packet.payload)
+    assert payload[0]["command"] == "comp_query"
+    assert payload[0]["device_id"] == "hws-1111-aaaa-2222-bbbb"
+    assert payload[0]["property_id"] == "prop-aaaa-1111-bbbb-2222"
+    assert payload[0]["hw_id"] == "aabbccddeeff"
+    assert payload[0]["direction"] == "app2gw"
+    assert payload[1] == {}
 
 
 def test_status_request_failure_during_reconnection_is_non_fatal(


### PR DESCRIPTION
## Summary by Sourcery

Switch reconnection and lifecycle handling to request fresh device status via MQTT and improve robustness of connection management and health checks.

New Features:
- Add MQTT-based status request helpers to trigger comp_query updates for individual and all HWS devices.

Bug Fixes:
- Prevent duplicate MQTT connections and timers by keeping the connection flag on transient disconnects and cancelling existing timers before starting new ones.
- Ensure connection health backoff uses rescheduled timers instead of blocking, avoiding timer-thread stalls and regressions in reconnection behaviour.
- Handle both upload_status and comp_query commands in MQTT updates so lifecycle-triggered status queries are correctly processed.

Enhancements:
- Request fresh HWS status via background threads on connection resume and during reconnection to avoid blocking MQTT callbacks and align behaviour with the official app.

Tests:
- Update reconnection behaviour tests to assert MQTT comp_query status requests, validate payload correctness, and ensure failures in status requests remain non-fatal.