### PR TITLE
fix: empty energy consumption

### DIFF
--- a/src/emerald_hws/emeraldhws.py
+++ b/src/emerald_hws/emeraldhws.py
@@ -567,17 +567,22 @@ class EmeraldHWS:
             for properties in self.properties:
                 for heat_pump in properties["heat_pump"]:
                     if heat_pump["id"] == id:
-                        # Get or create consumption data
-                        consumption = (
-                            json.loads(heat_pump["consumption_data"])
-                            if heat_pump.get("consumption_data")
-                            else {
-                                "current_hour": 0,
-                                "last_data_at": "",
-                                "past_seven_days": {},
-                                "monthly_consumption": {},
-                            }
-                        )
+                        # Get or create consumption data, treating null/malformed
+                        # consumption_data as no data
+                        default_consumption = {
+                            "current_hour": 0,
+                            "last_data_at": "",
+                            "past_seven_days": {},
+                            "monthly_consumption": {},
+                        }
+                        raw = heat_pump.get("consumption_data")
+                        if raw:
+                            try:
+                                consumption = json.loads(raw)
+                            except (ValueError, TypeError):
+                                consumption = dict(default_consumption)
+                        else:
+                            consumption = dict(default_consumption)
 
                         # Update current hour and timestamp
                         consumption["current_hour"] = current_hour_energy
@@ -755,6 +760,17 @@ class EmeraldHWS:
 
         return False
 
+    def _parseConsumption(self, full_status):
+        """Parses the consumption_data field, treating null/empty/malformed as no data
+        :param full_status: The full status dict for an HWS
+        :returns: Parsed consumption dict, or {} when no usable data is present
+        """
+        raw = full_status.get("consumption_data") or "{}"
+        try:
+            return json.loads(raw)
+        except (ValueError, TypeError):
+            return {}
+
     def getHourlyEnergyUsage(self, id):
         """Returns energy usage as reported by heater for the previous hour in kWh
         :param id: The UUID of the HWS to query
@@ -763,7 +779,7 @@ class EmeraldHWS:
         if not full_status:
             return None
 
-        consumption = json.loads(full_status.get("consumption_data", "{}"))
+        consumption = self._parseConsumption(full_status)
         return consumption.get("current_hour")
 
     def getDailyEnergyUsage(self, id):
@@ -775,7 +791,7 @@ class EmeraldHWS:
         if not full_status:
             return None
 
-        consumption = json.loads(full_status.get("consumption_data", "{}"))
+        consumption = self._parseConsumption(full_status)
         today = datetime.now().strftime("%Y-%m-%d")
         return consumption.get("past_seven_days", {}).get(today)
 
@@ -787,7 +803,7 @@ class EmeraldHWS:
         if not full_status:
             return None
 
-        consumption = json.loads(full_status.get("consumption_data", "{}"))
+        consumption = self._parseConsumption(full_status)
         return sum(consumption.get("past_seven_days", {}).values())
 
     def getMonthlyEnergyUsage(self, id):
@@ -798,7 +814,7 @@ class EmeraldHWS:
         if not full_status:
             return None
 
-        consumption = json.loads(full_status.get("consumption_data", "{}"))
+        consumption = self._parseConsumption(full_status)
         current_month = datetime.now().strftime("%Y-%m")
         return consumption.get("monthly_consumption", {}).get(current_month)
 
@@ -810,7 +826,7 @@ class EmeraldHWS:
         if not full_status:
             return None
 
-        return json.loads(full_status.get("consumption_data", "{}"))
+        return self._parseConsumption(full_status)
 
     def currentMode(self, id):
         """Returns an integer specifying the current mode (0==boost, 1==normal, 2==quiet)

--- a/src/emerald_hws/emeraldhws.py
+++ b/src/emerald_hws/emeraldhws.py
@@ -567,22 +567,12 @@ class EmeraldHWS:
             for properties in self.properties:
                 for heat_pump in properties["heat_pump"]:
                     if heat_pump["id"] == id:
-                        # Get or create consumption data, treating null/malformed
+                        # Get or create consumption data, treating null/malformed/non-object
                         # consumption_data as no data
-                        default_consumption = {
-                            "current_hour": 0,
-                            "last_data_at": "",
-                            "past_seven_days": {},
-                            "monthly_consumption": {},
+                        consumption = {
+                            **self._defaultConsumption(),
+                            **self._parseConsumption(heat_pump),
                         }
-                        raw = heat_pump.get("consumption_data")
-                        if raw:
-                            try:
-                                consumption = json.loads(raw)
-                            except (ValueError, TypeError):
-                                consumption = dict(default_consumption)
-                        else:
-                            consumption = dict(default_consumption)
 
                         # Update current hour and timestamp
                         consumption["current_hour"] = current_hour_energy
@@ -760,16 +750,26 @@ class EmeraldHWS:
 
         return False
 
+    def _defaultConsumption(self):
+        """Returns a fresh, empty consumption_data structure."""
+        return {
+            "current_hour": 0,
+            "last_data_at": "",
+            "past_seven_days": {},
+            "monthly_consumption": {},
+        }
+
     def _parseConsumption(self, full_status):
-        """Parses the consumption_data field, treating null/empty/malformed as no data
+        """Parses the consumption_data field, treating null/empty/malformed/non-object as no data
         :param full_status: The full status dict for an HWS
         :returns: Parsed consumption dict, or {} when no usable data is present
         """
         raw = full_status.get("consumption_data") or "{}"
         try:
-            return json.loads(raw)
+            parsed = json.loads(raw)
         except (ValueError, TypeError):
             return {}
+        return parsed if isinstance(parsed, dict) else {}
 
     def getHourlyEnergyUsage(self, id):
         """Returns energy usage as reported by heater for the previous hour in kWh

--- a/src/emerald_hws/emeraldhws.py
+++ b/src/emerald_hws/emeraldhws.py
@@ -750,7 +750,8 @@ class EmeraldHWS:
 
         return False
 
-    def _defaultConsumption(self):
+    @staticmethod
+    def _defaultConsumption():
         """Returns a fresh, empty consumption_data structure."""
         return {
             "current_hour": 0,
@@ -759,17 +760,30 @@ class EmeraldHWS:
             "monthly_consumption": {},
         }
 
-    def _parseConsumption(self, full_status):
+    @staticmethod
+    def _parseConsumption(full_status):
         """Parses the consumption_data field, treating null/empty/malformed/non-object as no data
         :param full_status: The full status dict for an HWS
         :returns: Parsed consumption dict, or {} when no usable data is present
         """
-        raw = full_status.get("consumption_data") or "{}"
-        try:
-            parsed = json.loads(raw)
-        except (ValueError, TypeError):
-            return {}
-        return parsed if isinstance(parsed, dict) else {}
+        raw = full_status.get("consumption_data")
+        if isinstance(raw, dict):
+            # Already-parsed structure; copy so normalization stays non-destructive
+            parsed = dict(raw)
+        else:
+            try:
+                parsed = json.loads(raw or "{}")
+            except (ValueError, TypeError):
+                return {}
+            if not isinstance(parsed, dict):
+                return {}
+
+        # Normalize the nested containers consumers iterate over so a malformed
+        # payload (e.g. a list where a dict is expected) can't crash the getters
+        for key in ("past_seven_days", "monthly_consumption"):
+            if key in parsed and not isinstance(parsed[key], dict):
+                parsed[key] = {}
+        return parsed
 
     def getHourlyEnergyUsage(self, id):
         """Returns energy usage as reported by heater for the previous hour in kWh

--- a/tests/test_query_operations.py
+++ b/tests/test_query_operations.py
@@ -2,6 +2,7 @@
 
 import copy
 import json
+import pytest
 from unittest.mock import Mock
 from emerald_hws import EmeraldHWS
 from .conftest import (
@@ -663,3 +664,78 @@ def test_get_daily_energy_usage_day_boundary_scenario():
     # Verify other methods still work
     weekly = client.getWeeklyEnergyUsage(hws_id)
     assert weekly == 4.2 + 3.8 + 4.1  # Should sum existing data
+
+
+# --- consumption_data parsing edge cases (no energy history) ---
+
+HWS_ID = "hws-1111-aaaa-2222-bbbb"
+
+
+def _make_client(consumption_data, omit=False):
+    """Builds a connected client with the heat pump's consumption_data set
+    to the given value (or removed entirely when omit is True)."""
+    client = EmeraldHWS("test@example.com", "password")
+    client.properties = copy.deepcopy(MOCK_PROPERTY_RESPONSE_SELF["info"]["property"])
+    heat_pump = client.properties[0]["heat_pump"][0]
+    if omit:
+        heat_pump.pop("consumption_data", None)
+    else:
+        heat_pump["consumption_data"] = consumption_data
+    client._is_connected = True
+    return client
+
+
+# (label, value, omit) — the three "no data" shapes that previously crashed
+NO_DATA_CASES = [
+    ("none", None, False),  # API returns key present but null (the bug)
+    ("empty_json", "{}", False),
+    ("missing", None, True),  # key absent entirely
+]
+
+
+@pytest.mark.parametrize("label,value,omit", NO_DATA_CASES)
+def test_energy_getters_no_data(label, value, omit):
+    """All energy getters treat null/empty/missing consumption_data as no data
+    rather than raising."""
+    client = _make_client(value, omit=omit)
+
+    assert client.getHourlyEnergyUsage(HWS_ID) is None
+    assert client.getDailyEnergyUsage(HWS_ID) is None
+    assert client.getWeeklyEnergyUsage(HWS_ID) == 0
+    assert client.getMonthlyEnergyUsage(HWS_ID) is None
+    assert client.getHistoricalConsumption(HWS_ID) == {}
+
+
+def test_energy_getters_populated_payload():
+    """A normal populated consumption_data still parses correctly (happy path)."""
+    from datetime import datetime
+
+    today = datetime.now().strftime("%Y-%m-%d")
+    current_month = datetime.now().strftime("%Y-%m")
+    payload = {
+        "current_hour": 0.42,
+        "last_data_at": f"{today} 09:00",
+        "past_seven_days": {today: 1.5},
+        "monthly_consumption": {current_month: 12.3},
+    }
+    client = _make_client(json.dumps(payload))
+
+    assert client.getHourlyEnergyUsage(HWS_ID) == 0.42
+    assert client.getDailyEnergyUsage(HWS_ID) == 1.5
+    assert client.getWeeklyEnergyUsage(HWS_ID) == 1.5
+    assert client.getMonthlyEnergyUsage(HWS_ID) == 12.3
+    assert client.getHistoricalConsumption(HWS_ID) == payload
+
+
+def test_update_energy_usage_with_null_consumption_data():
+    """The MQTT update path builds the default structure (rather than raising)
+    when consumption_data is null, and records the new hour."""
+    client = _make_client(None)
+
+    topic = f"ep/heat_pump/from_gw/{HWS_ID}"
+    client.mqttDecodeUpdate(topic, MQTT_MSG_ENERGY_UPDATE)
+
+    assert client.getHourlyEnergyUsage(HWS_ID) == 0.68
+    historical = client.getHistoricalConsumption(HWS_ID)
+    assert historical["past_seven_days"]["2099-12-31"] == 0.68
+    assert historical["monthly_consumption"]["2099-12"] == 0.68

--- a/tests/test_query_operations.py
+++ b/tests/test_query_operations.py
@@ -685,11 +685,15 @@ def _make_client(consumption_data, omit=False):
     return client
 
 
-# (label, value, omit) — the three "no data" shapes that previously crashed
+# (label, value, omit) — the "no data" shapes _parseConsumption must tolerate
 NO_DATA_CASES = [
     ("none", None, False),  # API returns key present but null (the bug)
-    ("empty_json", "{}", False),
+    ("empty_json", "{}", False),  # empty JSON object
     ("missing", None, True),  # key absent entirely
+    ("not_json", "not-json", False),  # malformed, non-JSON string
+    ("bad_json", "{bad}", False),  # syntactically invalid JSON
+    ("empty_string", "", False),  # empty string payload
+    ("json_null", "null", False),  # valid JSON but not an object
 ]
 
 
@@ -710,8 +714,9 @@ def test_energy_getters_populated_payload():
     """A normal populated consumption_data still parses correctly (happy path)."""
     from datetime import datetime
 
-    today = datetime.now().strftime("%Y-%m-%d")
-    current_month = datetime.now().strftime("%Y-%m")
+    now = datetime.now()
+    today = now.strftime("%Y-%m-%d")
+    current_month = now.strftime("%Y-%m")
     payload = {
         "current_hour": 0.42,
         "last_data_at": f"{today} 09:00",
@@ -727,10 +732,11 @@ def test_energy_getters_populated_payload():
     assert client.getHistoricalConsumption(HWS_ID) == payload
 
 
-def test_update_energy_usage_with_null_consumption_data():
+@pytest.mark.parametrize("consumption_data", [None, "not-json", "null", ""])
+def test_update_energy_usage_with_no_prior_data(consumption_data):
     """The MQTT update path builds the default structure (rather than raising)
-    when consumption_data is null, and records the new hour."""
-    client = _make_client(None)
+    when consumption_data is null/malformed/non-object, and records the new hour."""
+    client = _make_client(consumption_data)
 
     topic = f"ep/heat_pump/from_gw/{HWS_ID}"
     client.mqttDecodeUpdate(topic, MQTT_MSG_ENERGY_UPDATE)

--- a/tests/test_query_operations.py
+++ b/tests/test_query_operations.py
@@ -3,7 +3,8 @@
 import copy
 import json
 import pytest
-from unittest.mock import Mock
+from datetime import datetime
+from unittest.mock import Mock, patch
 from emerald_hws import EmeraldHWS
 from .conftest import (
     MOCK_LOGIN_RESPONSE,
@@ -652,8 +653,6 @@ def test_get_daily_energy_usage_day_boundary_scenario():
     hws_id = "hws-1111-aaaa-2222-bbbb"
 
     # Mock datetime to return a date not in the data
-    from unittest.mock import patch
-
     with patch("emerald_hws.emeraldhws.datetime") as mock_datetime:
         mock_datetime.now.return_value.strftime.return_value = "2025-10-15"
 
@@ -710,13 +709,31 @@ def test_energy_getters_no_data(label, value, omit):
     assert client.getHistoricalConsumption(HWS_ID) == {}
 
 
+def test_malformed_nested_consumption_data_normalization():
+    """Nested containers that aren't dicts are normalized to {} so the getters
+    don't crash on a malformed-but-valid-JSON payload."""
+    malformed = json.dumps(
+        {
+            "current_hour": 0.5,
+            "past_seven_days": ["not", "a", "dict"],
+            "monthly_consumption": "also-not-a-dict",
+        }
+    )
+    client = _make_client(malformed)
+
+    assert client.getHourlyEnergyUsage(HWS_ID) == 0.5  # scalar untouched
+    assert client.getWeeklyEnergyUsage(HWS_ID) == 0  # list -> {} -> sum() == 0
+    assert client.getMonthlyEnergyUsage(HWS_ID) is None  # str -> {} -> no month
+    historical = client.getHistoricalConsumption(HWS_ID)
+    assert historical["past_seven_days"] == {}
+    assert historical["monthly_consumption"] == {}
+
+
 def test_energy_getters_populated_payload():
     """A normal populated consumption_data still parses correctly (happy path)."""
-    from datetime import datetime
-
-    now = datetime.now()
-    today = now.strftime("%Y-%m-%d")
-    current_month = now.strftime("%Y-%m")
+    # Fixed dates so the test stays deterministic across day/month boundaries
+    today = "2099-12-31"
+    current_month = "2099-12"
     payload = {
         "current_hour": 0.42,
         "last_data_at": f"{today} 09:00",
@@ -725,18 +742,30 @@ def test_energy_getters_populated_payload():
     }
     client = _make_client(json.dumps(payload))
 
-    assert client.getHourlyEnergyUsage(HWS_ID) == 0.42
-    assert client.getDailyEnergyUsage(HWS_ID) == 1.5
-    assert client.getWeeklyEnergyUsage(HWS_ID) == 1.5
-    assert client.getMonthlyEnergyUsage(HWS_ID) == 12.3
-    assert client.getHistoricalConsumption(HWS_ID) == payload
+    with patch("emerald_hws.emeraldhws.datetime") as mock_dt:
+        mock_dt.now.return_value = datetime(2099, 12, 31)
+
+        assert client.getHourlyEnergyUsage(HWS_ID) == 0.42
+        assert client.getDailyEnergyUsage(HWS_ID) == 1.5
+        assert client.getWeeklyEnergyUsage(HWS_ID) == 1.5
+        assert client.getMonthlyEnergyUsage(HWS_ID) == 12.3
+        assert client.getHistoricalConsumption(HWS_ID) == payload
 
 
-@pytest.mark.parametrize("consumption_data", [None, "not-json", "null", ""])
-def test_update_energy_usage_with_no_prior_data(consumption_data):
+@pytest.mark.parametrize(
+    "consumption_data,omit",
+    [
+        (None, False),
+        ("not-json", False),
+        ("null", False),
+        ("", False),
+        (None, True),  # key entirely absent
+    ],
+)
+def test_update_energy_usage_with_no_prior_data(consumption_data, omit):
     """The MQTT update path builds the default structure (rather than raising)
-    when consumption_data is null/malformed/non-object, and records the new hour."""
-    client = _make_client(consumption_data)
+    when consumption_data is null/malformed/non-object/absent, and records the new hour."""
+    client = _make_client(consumption_data, omit=omit)
 
     topic = f"ep/heat_pump/from_gw/{HWS_ID}"
     client.mqttDecodeUpdate(topic, MQTT_MSG_ENERGY_UPDATE)
@@ -745,3 +774,30 @@ def test_update_energy_usage_with_no_prior_data(consumption_data):
     historical = client.getHistoricalConsumption(HWS_ID)
     assert historical["past_seven_days"]["2099-12-31"] == 0.68
     assert historical["monthly_consumption"]["2099-12"] == 0.68
+
+
+def test_update_energy_usage_preserves_existing_history():
+    """The MQTT update path merges non-destructively: prior days/months are kept,
+    while the new hour accumulates into the matching day and month."""
+    # MQTT_MSG_ENERGY_UPDATE reports 0.68 kWh for start_time 2099-12-31 09:00
+    existing = {
+        "current_hour": 1.0,
+        "last_data_at": "2099-12-30 10:00",
+        "past_seven_days": {"2099-12-30": 2.0, "2099-12-31": 0.32},
+        "monthly_consumption": {"2099-11": 50.0, "2099-12": 5.0},
+    }
+    client = _make_client(json.dumps(existing))
+
+    topic = f"ep/heat_pump/from_gw/{HWS_ID}"
+    client.mqttDecodeUpdate(topic, MQTT_MSG_ENERGY_UPDATE)
+
+    assert client.getHourlyEnergyUsage(HWS_ID) == 0.68
+    historical = client.getHistoricalConsumption(HWS_ID)
+
+    # Prior day untouched; same day accumulates the new hour
+    assert historical["past_seven_days"]["2099-12-30"] == 2.0
+    assert historical["past_seven_days"]["2099-12-31"] == pytest.approx(0.32 + 0.68)
+
+    # Prior month untouched; current month accumulates the new hour
+    assert historical["monthly_consumption"]["2099-11"] == 50.0
+    assert historical["monthly_consumption"]["2099-12"] == pytest.approx(5.0 + 0.68)

--- a/tests/test_query_operations.py
+++ b/tests/test_query_operations.py
@@ -709,17 +709,18 @@ def test_energy_getters_no_data(label, value, omit):
     assert client.getHistoricalConsumption(HWS_ID) == {}
 
 
-def test_malformed_nested_consumption_data_normalization():
-    """Nested containers that aren't dicts are normalized to {} so the getters
-    don't crash on a malformed-but-valid-JSON payload."""
-    malformed = json.dumps(
-        {
-            "current_hour": 0.5,
-            "past_seven_days": ["not", "a", "dict"],
-            "monthly_consumption": "also-not-a-dict",
-        }
-    )
-    client = _make_client(malformed)
+@pytest.mark.parametrize(
+    "as_dict", [False, True], ids=["json_string", "dict_fast_path"]
+)
+def test_malformed_nested_consumption_data_normalization(as_dict):
+    """Nested containers that aren't dicts are normalized to {} so the getters don't
+    crash — for both the JSON-string and the already-parsed-dict (fast-path) inputs."""
+    payload = {
+        "current_hour": 0.5,
+        "past_seven_days": ["not", "a", "dict"],
+        "monthly_consumption": "also-not-a-dict",
+    }
+    client = _make_client(payload if as_dict else json.dumps(payload))
 
     assert client.getHourlyEnergyUsage(HWS_ID) == 0.5  # scalar untouched
     assert client.getWeeklyEnergyUsage(HWS_ID) == 0  # list -> {} -> sum() == 0


### PR DESCRIPTION
## Summary by Sourcery

Handle missing and malformed heat pump energy consumption data without crashing and ensure energy usage getters and updates behave consistently when no prior data exists.

Bug Fixes:
- Treat null, missing, empty, or malformed consumption_data as absence of data so energy usage getters and MQTT updates no longer raise errors.
- Normalize malformed nested consumption_data structures so energy usage calculations and history retrieval remain robust.

Enhancements:
- Introduce shared helpers to parse and default the consumption_data structure and reuse them across energy usage getters and update logic.

Tests:
- Add comprehensive tests covering edge cases for empty, missing, and malformed consumption_data, as well as normal and MQTT update scenarios.