### PR TITLE
feat: refactor connection handling, fix dropped control messages

### DIFF
--- a/src/emerald_hws/__init__.py
+++ b/src/emerald_hws/__init__.py
@@ -1,3 +1,9 @@
 from .emeraldhws import EmeraldHWS
+from .exceptions import EmeraldConnectionError, EmeraldError, EmeraldTimeoutError
 
-__all__ = ["EmeraldHWS"]
+__all__ = [
+    "EmeraldHWS",
+    "EmeraldError",
+    "EmeraldConnectionError",
+    "EmeraldTimeoutError",
+]

--- a/src/emerald_hws/emeraldhws.py
+++ b/src/emerald_hws/emeraldhws.py
@@ -3,12 +3,15 @@ import logging
 import random
 import threading
 import time
+from concurrent.futures import TimeoutError as FuturesTimeoutError
 from datetime import datetime
 
 import boto3
 import requests
 from awscrt import mqtt5, auth, io
 from awsiot import mqtt5_client_builder
+
+from .exceptions import EmeraldConnectionError, EmeraldError, EmeraldTimeoutError
 
 
 class EmeraldHWS:
@@ -56,7 +59,13 @@ class EmeraldHWS:
         self._mqtt_lock = (
             threading.RLock()
         )  # Lock to protect MQTT client lifecycle operations
-        self._is_connected = False  # Flag to track connection state
+        # Tracks whether connect() has finished its full setup (login, HWS
+        # discovery, MQTT, subscriptions, timers). This is NOT a measure of
+        # whether the socket is currently up - transient disconnects leave it
+        # True on purpose, so that getFullStatus/listHWS do not call connect()
+        # and stand up a competing MQTT connection. For live connection state,
+        # use self._connection_event.
+        self._setup_complete = False
         self.mqttClient = None  # Initialise to None
 
         # Convert minutes to seconds for internal use
@@ -222,6 +231,37 @@ class EmeraldHWS:
         # Request fresh status from all HWS via MQTT (like the official app does)
         self._request_status_updates_safe()
 
+    def _ensure_mqtt_connected(self, reason, allow_reconnect=True, timeout=5):
+        """Ensures the MQTT connection is live before an operation is published.
+
+        Without this, a publish issued while disconnected goes into the mqtt5
+        client's offline queue and, at QoS 1, its future only resolves on a
+        PUBACK that never arrives - so the caller blocks for the full result()
+        timeout and the command is silently never delivered.
+
+        Must be called with no lock held: reconnectMQTT takes self._mqtt_lock
+        and can hold it for some time while the new connection is established.
+
+        :param reason: Reason for reconnection, passed through to reconnectMQTT
+        :param allow_reconnect: Whether a down connection should trigger a
+            reconnect. Pass False on paths that are reachable from within
+            reconnectMQTT itself, to avoid re-entering it.
+        :param timeout: Seconds to wait for the connection to come up
+        :raises EmeraldConnectionError: if the connection is not live in time
+        """
+        if self._connection_event.is_set():
+            return
+
+        if allow_reconnect:
+            self.logger.info(
+                "emeraldhws: awsiot: connection is down, reconnecting before "
+                f"publish (reason: {reason})"
+            )
+            self.reconnectMQTT(reason=reason)
+
+        if not self._connection_event.wait(timeout=timeout):
+            raise EmeraldConnectionError("MQTT connection unavailable")
+
     def _request_status_updates_safe(self):
         """Request status updates from all HWS, logging any failures."""
         try:
@@ -277,8 +317,10 @@ class EmeraldHWS:
                 on_lifecycle_disconnection=self.on_lifecycle_disconnection,
                 on_lifecycle_connection_failure=self.on_lifecycle_connection_failure,
                 on_publish_received=self.mqttCallback,
-                # The default keep-alive is 20 minutes, which we might want to reduce
-                # keep_alive_interval_sec = 60,
+                # The aws-crt default is 20 minutes, which means a half-open
+                # socket can go undetected for that long. AWS IoT accepts
+                # 30-1200 seconds; 60 gets a dead socket noticed in ~60-90s.
+                keep_alive_interval_sec=60,
             )
 
             client.start()
@@ -457,10 +499,12 @@ class EmeraldHWS:
 
         self.logger.info(f"emeraldhws: awsiot: disconnected - {reason}")
 
-        # Do NOT set _is_connected = False here. The AWS IoT SDK handles
+        # Do NOT set _setup_complete = False here. The AWS IoT SDK handles
         # transient disconnections automatically (interrupt → auto-reconnect → resume).
-        # Setting _is_connected = False would cause getFullStatus/sendControlMessage
-        # to call connect(), creating a competing MQTT connection and duplicate timers.
+        # Setting _setup_complete = False would cause getFullStatus/listHWS to
+        # call connect(), creating a competing MQTT connection and duplicate timers.
+        # Clearing _connection_event is what makes the publish paths notice: they
+        # gate on it via _ensure_mqtt_connected rather than on _setup_complete.
         self._connection_event.clear()
         return
 
@@ -610,7 +654,9 @@ class EmeraldHWS:
             while not self.mqttClient:
                 self.connectMQTT()
                 if retry >= 3:
-                    raise Exception("MQTT client not connected after multiple attempts")
+                    raise EmeraldConnectionError(
+                        "MQTT client not connected after multiple attempts"
+                    )
                 retry += 1
 
             mqtt_topic = "ep/heat_pump/from_gw/{}".format(id)
@@ -625,14 +671,23 @@ class EmeraldHWS:
             )
 
             # Wait for subscription to complete
-            subscribe_future.result(20)
+            try:
+                subscribe_future.result(20)
+            except (FuturesTimeoutError, TimeoutError) as e:
+                raise EmeraldTimeoutError(
+                    f"Timed out subscribing to updates for HWS {id}"
+                ) from e
+            except Exception as e:
+                raise EmeraldConnectionError(
+                    f"Failed to subscribe to updates for HWS {id}: {e}"
+                ) from e
 
     def getFullStatus(self, id):
         """Returns a dict with the full status of the specified HWS
         :param id: UUID of the HWS to get the status for
         """
 
-        if not self._is_connected:
+        if not self._setup_complete:
             self.connect()
 
         with self._state_lock:
@@ -649,12 +704,10 @@ class EmeraldHWS:
         :param payload: JSON payload to send eg {"switch":1}
         """
 
-        if not self._is_connected:
-            self.connect()
-
+        # getFullStatus performs the cold-start connect() if needed
         hwsdetail = self.getFullStatus(id)
         if not hwsdetail:
-            raise Exception(f"Unable to find HWS with ID {id}")
+            raise EmeraldError(f"Unable to find HWS with ID {id}")
 
         msg = [
             {
@@ -670,9 +723,12 @@ class EmeraldHWS:
         ]
         mqtt_topic = "ep/heat_pump/to_gw/{}".format(id)
 
+        # Must run outside self._mqtt_lock - it may reconnect, which takes it
+        self._ensure_mqtt_connected(reason="control_message")
+
         with self._mqtt_lock:
             if not self.mqttClient:
-                raise Exception("MQTT client not connected")
+                raise EmeraldConnectionError("MQTT client not connected")
             publish_future = self.mqttClient.publish(
                 mqtt5.PublishPacket(
                     topic=mqtt_topic,
@@ -682,7 +738,16 @@ class EmeraldHWS:
             )
 
         # Wait for publish to complete outside the lock
-        publish_future.result(20)  # 20 seconds
+        try:
+            publish_future.result(20)  # 20 seconds
+        except (FuturesTimeoutError, TimeoutError) as e:
+            raise EmeraldTimeoutError(
+                f"Timed out publishing control message to HWS {id}"
+            ) from e
+        except Exception as e:
+            raise EmeraldConnectionError(
+                f"Failed to publish control message to HWS {id}: {e}"
+            ) from e
 
     def turnOn(self, id):
         """Turns the specified HWS on
@@ -869,7 +934,7 @@ class EmeraldHWS:
 
     def listHWS(self):
         """Returns a list of UUIDs of all discovered HWS"""
-        if not self._is_connected:
+        if not self._setup_complete:
             self.connect()
 
         properties_list = self._wait_for_properties()
@@ -897,7 +962,7 @@ class EmeraldHWS:
         """
         hwsdetail = self.getFullStatus(id)
         if not hwsdetail:
-            raise Exception(f"Unable to find HWS with ID {id}")
+            raise EmeraldError(f"Unable to find HWS with ID {id}")
 
         msg = [
             {
@@ -913,9 +978,15 @@ class EmeraldHWS:
         ]
         mqtt_topic = "ep/heat_pump/to_gw/{}".format(id)
 
+        # allow_reconnect=False: reconnectMQTT calls _request_status_updates_safe,
+        # which reaches this method, so reconnecting here would re-enter it -
+        # and requestAllStatusUpdates fans out over a thread pool, so every
+        # worker would trigger its own reconnect.
+        self._ensure_mqtt_connected(reason="status_update", allow_reconnect=False)
+
         with self._mqtt_lock:
             if not self.mqttClient:
-                raise Exception("MQTT client not connected")
+                raise EmeraldConnectionError("MQTT client not connected")
             publish_future = self.mqttClient.publish(
                 mqtt5.PublishPacket(
                     topic=mqtt_topic,
@@ -924,7 +995,16 @@ class EmeraldHWS:
                 )
             )
 
-        publish_future.result(20)
+        try:
+            publish_future.result(20)
+        except (FuturesTimeoutError, TimeoutError) as e:
+            raise EmeraldTimeoutError(
+                f"Timed out requesting status update from HWS {id}"
+            ) from e
+        except Exception as e:
+            raise EmeraldConnectionError(
+                f"Failed to request status update from HWS {id}: {e}"
+            ) from e
         self.logger.debug(f"emeraldhws: Sent comp_query to HWS {id}")
 
     def requestAllStatusUpdates(self):
@@ -967,7 +1047,7 @@ class EmeraldHWS:
         # Use lock to ensure only one thread can connect at a time
         with self._connect_lock:
             # Double-check pattern: check again inside the lock
-            if self._is_connected:
+            if self._setup_complete:
                 self.logger.debug("emeraldhws: Already connected, skipping")
                 return
 
@@ -976,7 +1056,7 @@ class EmeraldHWS:
             self.getAllHWS()
             self.connectMQTT()
             self.subscribeAllHWS()
-            self._is_connected = True
+            self._setup_complete = True
 
             # Cancel any existing timers before starting new ones to prevent accumulation
             if self.reconnect_timer:
@@ -1030,5 +1110,5 @@ class EmeraldHWS:
                 finally:
                     self.mqttClient = None
 
-            self._is_connected = False
+            self._setup_complete = False
             self._connection_event.clear()

--- a/src/emerald_hws/emeraldhws.py
+++ b/src/emerald_hws/emeraldhws.py
@@ -191,11 +191,26 @@ class EmeraldHWS:
 
         self.update_callback = update_callback
 
-    def reconnectMQTT(self, reason="scheduled"):
+    def reconnectMQTT(self, reason="scheduled", skip_if_connected=False):
         """Stops an existing MQTT connection and creates a new one
         :param reason: Reason for reconnection (scheduled, health_check, etc.)
+        :param skip_if_connected: If True, do nothing when the connection came
+            back while this call was waiting for the lock. Callers reconnecting
+            *because* the connection is down should pass True; scheduled and
+            health-check reconnects want the rebuild regardless.
         """
         with self._mqtt_lock:
+            # Re-checked under the lock: several threads can observe the same
+            # disconnect and queue up here. Without this, the second one stops
+            # the healthy client the first just built - and any QoS 1 publish
+            # already in flight on it never gets its PUBACK.
+            if skip_if_connected and self._connection_event.is_set():
+                self.logger.debug(
+                    "emeraldhws: awsiot: connection already restored, skipping "
+                    f"reconnect (reason: {reason})"
+                )
+                return
+
             self.logger.info(
                 f"emeraldhws: awsiot: Reconnecting MQTT connection (reason: {reason})"
             )
@@ -235,9 +250,12 @@ class EmeraldHWS:
         """Ensures the MQTT connection is live before an operation is published.
 
         Without this, a publish issued while disconnected goes into the mqtt5
-        client's offline queue and, at QoS 1, its future only resolves on a
-        PUBACK that never arrives - so the caller blocks for the full result()
-        timeout and the command is silently never delivered.
+        client's offline queue. At QoS 1 the future only resolves on a PUBACK,
+        so the caller blocks for the full result() timeout and is told the
+        command failed - but awscrt's default offline queue behaviour
+        (FAIL_QOS0_PUBLISH_ON_DISCONNECT) re-queues un-acked QoS 1 publishes
+        for retransmission, so the command can still be delivered much later,
+        long after the caller gave up on it.
 
         Must be called with no lock held: reconnectMQTT takes self._mqtt_lock
         and can hold it for some time while the new connection is established.
@@ -246,18 +264,37 @@ class EmeraldHWS:
         :param allow_reconnect: Whether a down connection should trigger a
             reconnect. Pass False on paths that are reachable from within
             reconnectMQTT itself, to avoid re-entering it.
-        :param timeout: Seconds to wait for the connection to come up
+        :param timeout: Seconds to wait for the connection to come up, both
+            before and after any reconnect
         :raises EmeraldConnectionError: if the connection is not live in time
         """
         if self._connection_event.is_set():
             return
 
-        if allow_reconnect:
-            self.logger.info(
-                "emeraldhws: awsiot: connection is down, reconnecting before "
-                f"publish (reason: {reason})"
-            )
-            self.reconnectMQTT(reason=reason)
+        # Give the SDK's own auto-reconnect a chance first. A transient drop
+        # clears _connection_event, but awscrt is already reconnecting with
+        # backoff and usually recovers within seconds. Tearing the client down
+        # here would abort that and force a full rebuild (Cognito, websocket,
+        # re-subscribe every topic) for a blip that would have healed itself.
+        if self._connection_event.wait(timeout=timeout):
+            return
+
+        if not allow_reconnect:
+            raise EmeraldConnectionError("MQTT connection unavailable")
+
+        self.logger.info(
+            "emeraldhws: awsiot: connection still down after "
+            f"{timeout}s, reconnecting before publish (reason: {reason})"
+        )
+        try:
+            self.reconnectMQTT(reason=reason, skip_if_connected=True)
+        except EmeraldError:
+            raise
+        except Exception as e:
+            # connectMQTT makes live Cognito calls, so this is a likely
+            # failure during the outage that got us here. Don't leak
+            # botocore/awscrt types to callers.
+            raise EmeraldConnectionError(f"Unable to reconnect to MQTT: {e}") from e
 
         if not self._connection_event.wait(timeout=timeout):
             raise EmeraldConnectionError("MQTT connection unavailable")
@@ -517,7 +554,15 @@ class EmeraldHWS:
 
     def scheduled_reconnect(self):
         """Periodic MQTT reconnect - called by timer and reschedules itself"""
-        self.reconnectMQTT(reason="scheduled")
+        try:
+            self.reconnectMQTT(reason="scheduled")
+        except Exception as e:
+            # Must not propagate: it would skip the reschedule below and this
+            # process would then never reconnect again for its whole lifetime.
+            self.logger.warning(
+                f"emeraldhws: awsiot: Scheduled reconnect failed, will retry "
+                f"at the next interval: {e}"
+            )
 
         # Reschedule for next time
         if self.connection_timeout > 0:
@@ -564,7 +609,15 @@ class EmeraldHWS:
                         self.health_check_timer.start()
                     return
 
-                self.reconnectMQTT(reason="health_check")
+                try:
+                    self.reconnectMQTT(reason="health_check")
+                except Exception as e:
+                    # As in scheduled_reconnect: swallow so the reschedule at
+                    # the end of this method always runs.
+                    self.logger.warning(
+                        f"emeraldhws: awsiot: Health check reconnect failed, "
+                        f"will retry at the next interval: {e}"
+                    )
             else:
                 # This is a DEBUG level log to avoid cluttering logs
                 self.logger.debug(

--- a/src/emerald_hws/exceptions.py
+++ b/src/emerald_hws/exceptions.py
@@ -1,0 +1,22 @@
+"""Exceptions raised by the emerald_hws library.
+
+Callers should be able to catch failures from this library without knowing
+anything about its transport. Every error raised deliberately by this package
+derives from :class:`EmeraldError`.
+"""
+
+
+class EmeraldError(Exception):
+    """Base class for all errors raised by this library."""
+
+
+class EmeraldConnectionError(EmeraldError):
+    """The MQTT connection is unavailable or could not be established."""
+
+
+class EmeraldTimeoutError(EmeraldError, TimeoutError):
+    """An MQTT operation did not complete within its deadline.
+
+    Also derives from the builtin :class:`TimeoutError` so that callers already
+    handling transport timeouts keep working unchanged.
+    """

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -370,6 +370,21 @@ def make_mqtt_update(device_id, property_id, **updates):
     return json.dumps(msg).encode("utf-8")
 
 
+def mark_connected(client, mocker):
+    """Make a client look fully connected to both connection checks.
+
+    Two different checks read _connection_event and both need mocking:
+
+    - connectMQTT() blocks on .wait(timeout=30) for the lifecycle callback,
+      which never fires under mocks.
+    - _ensure_mqtt_connected() reads .is_set() before every publish/subscribe.
+      Without this the real Event stays clear (only the success callback ever
+      calls .set()), so publish paths would take the reconnect branch.
+    """
+    mocker.patch.object(client._connection_event, "wait", return_value=True)
+    mocker.patch.object(client._connection_event, "is_set", return_value=True)
+
+
 @pytest.fixture
 def mock_requests(mocker):
     """Mock requests library for API calls."""
@@ -439,7 +454,8 @@ def mqtt_client_with_properties():
 
     client = EmeraldHWS("test@example.com", "password")
     client.properties = copy.deepcopy(MOCK_PROPERTY_RESPONSE_SELF["info"]["property"])
-    client._is_connected = True  # Set connected flag to bypass connection checks
+    client._setup_complete = True  # Bypass the cold-start connect()
+    client._connection_event.set()  # Bypass the pre-publish connection gate
 
     return {
         "client": client,

--- a/tests/test_connection_gating.py
+++ b/tests/test_connection_gating.py
@@ -1,0 +1,288 @@
+"""Tests for gating MQTT operations on real connection state.
+
+Regression cover for the bug where a control message sent during a live
+disconnect went into the mqtt5 client's offline queue and, at QoS 1, blocked
+the caller for the full 20s publish timeout before raising a bare TimeoutError
+- with the command never delivered.
+
+The guard that was supposed to prevent this read _setup_complete (then named
+_is_connected), which is deliberately never cleared on a transient disconnect,
+so it was dead code. The gate now reads _connection_event instead.
+"""
+
+import json
+import time
+from concurrent.futures import TimeoutError as FuturesTimeoutError
+from unittest.mock import Mock
+
+import pytest
+
+from emerald_hws import (
+    EmeraldConnectionError,
+    EmeraldError,
+    EmeraldHWS,
+    EmeraldTimeoutError,
+)
+from .conftest import (
+    MOCK_LOGIN_RESPONSE,
+    MOCK_PROPERTY_RESPONSE_SELF,
+    mark_connected,
+)
+
+HWS_ID = "hws-1111-aaaa-2222-bbbb"
+
+
+def _connected_client(mock_requests, mocker):
+    """Build a client that has completed connect() and believes it is live."""
+    mock_login = Mock()
+    mock_login.json.return_value = MOCK_LOGIN_RESPONSE
+    mock_requests.post.return_value = mock_login
+
+    mock_properties = Mock()
+    mock_properties.json.return_value = MOCK_PROPERTY_RESPONSE_SELF
+    mock_requests.get.return_value = mock_properties
+
+    client = EmeraldHWS("test@example.com", "password")
+    mark_connected(client, mocker)
+    client.connect()
+    return client
+
+
+def _simulate_disconnect(client, mocker, comes_back=False):
+    """Simulate a live disconnect: socket down, setup still complete.
+
+    This is the state on_lifecycle_disconnection leaves behind - it clears
+    _connection_event but deliberately leaves _setup_complete True.
+
+    :param comes_back: whether the subsequent wait() should report success
+    :returns: the patched wait mock, for asserting the timeout used
+    """
+    mocker.patch.object(client._connection_event, "is_set", return_value=False)
+    return mocker.patch.object(
+        client._connection_event, "wait", return_value=comes_back
+    )
+
+
+def test_control_message_during_disconnect_reconnects_and_fails_fast(
+    mock_requests, mock_boto3, mock_mqtt5_client_builder, mock_auth, mock_io, mocker
+):
+    """The headline case: a control message sent while disconnected must
+    trigger a reconnect and raise a typed error, not block for 20s in the
+    offline queue waiting for a PUBACK that will never arrive."""
+    client = _connected_client(mock_requests, mocker)
+    mqtt_client = (
+        mock_mqtt5_client_builder.websockets_with_default_aws_signing.return_value
+    )
+
+    wait_mock = _simulate_disconnect(client, mocker)
+    reconnect = mocker.patch.object(client, "reconnectMQTT")
+
+    started = time.monotonic()
+    with pytest.raises(EmeraldConnectionError) as exc_info:
+        client.turnOn(HWS_ID)
+    elapsed = time.monotonic() - started
+
+    # Reconnects via reconnectMQTT, NOT connect() - connect() would stand up a
+    # competing MQTT connection with duplicate timers.
+    reconnect.assert_called_once_with(reason="control_message")
+
+    # Nothing was handed to the offline queue.
+    mqtt_client.publish.assert_not_called()
+
+    assert "MQTT connection unavailable" in str(exc_info.value)
+
+    # The wait is bounded at 5s, not the 20s publish timeout it replaces.
+    wait_mock.assert_called_once_with(timeout=5)
+    assert elapsed < 5
+
+
+def test_control_message_publishes_normally_when_connected(
+    mock_requests, mock_boto3, mock_mqtt5_client_builder, mock_auth, mock_io, mocker
+):
+    """Happy path regression guard: a live connection must not reconnect."""
+    client = _connected_client(mock_requests, mocker)
+    mqtt_client = (
+        mock_mqtt5_client_builder.websockets_with_default_aws_signing.return_value
+    )
+    reconnect = mocker.patch.object(client, "reconnectMQTT")
+
+    client.turnOn(HWS_ID)
+
+    reconnect.assert_not_called()
+    mqtt_client.publish.assert_called_once()
+
+
+def test_control_message_publishes_after_successful_reconnect(
+    mock_requests, mock_boto3, mock_mqtt5_client_builder, mock_auth, mock_io, mocker
+):
+    """When the reconnect brings the connection back, the publish goes ahead
+    with an unchanged payload."""
+    client = _connected_client(mock_requests, mocker)
+    mqtt_client = (
+        mock_mqtt5_client_builder.websockets_with_default_aws_signing.return_value
+    )
+
+    _simulate_disconnect(client, mocker, comes_back=True)
+    reconnect = mocker.patch.object(client, "reconnectMQTT")
+
+    client.turnOn(HWS_ID)
+
+    reconnect.assert_called_once_with(reason="control_message")
+    mqtt_client.publish.assert_called_once()
+
+    publish_packet = mqtt_client.publish.call_args[0][0]
+    assert publish_packet.topic == f"ep/heat_pump/to_gw/{HWS_ID}"
+    header, payload = json.loads(publish_packet.payload)
+    assert header["command"] == "control"
+    assert header["device_id"] == HWS_ID
+    assert payload == {"switch": 1}
+
+
+def test_status_update_during_disconnect_does_not_reconnect(
+    mock_requests, mock_boto3, mock_mqtt5_client_builder, mock_auth, mock_io, mocker
+):
+    """requestStatusUpdate is reachable from inside reconnectMQTT (via
+    _request_status_updates_safe), so its gate must never reconnect - that
+    would have a reconnect re-enter itself, once per thread-pool worker."""
+    client = _connected_client(mock_requests, mocker)
+    mqtt_client = (
+        mock_mqtt5_client_builder.websockets_with_default_aws_signing.return_value
+    )
+
+    _simulate_disconnect(client, mocker)
+    reconnect = mocker.patch.object(client, "reconnectMQTT")
+
+    with pytest.raises(EmeraldConnectionError):
+        client.requestStatusUpdate(HWS_ID)
+
+    reconnect.assert_not_called()
+    mqtt_client.publish.assert_not_called()
+
+
+def test_status_update_publishes_normally_when_connected(
+    mock_requests, mock_boto3, mock_mqtt5_client_builder, mock_auth, mock_io, mocker
+):
+    """The wait-only gate must not break the normal status refresh."""
+    client = _connected_client(mock_requests, mocker)
+    mqtt_client = (
+        mock_mqtt5_client_builder.websockets_with_default_aws_signing.return_value
+    )
+
+    client.requestStatusUpdate(HWS_ID)
+
+    mqtt_client.publish.assert_called_once()
+    header, _ = json.loads(mqtt_client.publish.call_args[0][0].payload)
+    assert header["command"] == "comp_query"
+
+
+@pytest.mark.parametrize("raised", [FuturesTimeoutError, TimeoutError])
+def test_publish_timeout_becomes_emerald_timeout_error(
+    raised,
+    mock_requests,
+    mock_boto3,
+    mock_mqtt5_client_builder,
+    mock_auth,
+    mock_io,
+    mocker,
+):
+    """A publish timeout must surface as EmeraldTimeoutError, which still
+    subclasses the builtin TimeoutError so the consuming Home Assistant
+    integration's `except TimeoutError` arm keeps working unchanged.
+
+    concurrent.futures.TimeoutError is only an alias of the builtin on Python
+    3.11+, so both are exercised.
+    """
+    client = _connected_client(mock_requests, mocker)
+    mqtt_client = (
+        mock_mqtt5_client_builder.websockets_with_default_aws_signing.return_value
+    )
+    mqtt_client.publish.return_value = Mock(result=Mock(side_effect=raised()))
+
+    with pytest.raises(EmeraldTimeoutError) as exc_info:
+        client.turnOn(HWS_ID)
+
+    assert isinstance(exc_info.value, TimeoutError)
+    assert isinstance(exc_info.value, EmeraldError)
+    assert HWS_ID in str(exc_info.value)
+
+
+def test_publish_transport_error_becomes_emerald_connection_error(
+    mock_requests, mock_boto3, mock_mqtt5_client_builder, mock_auth, mock_io, mocker
+):
+    """Non-timeout transport failures must not leak to callers either."""
+    client = _connected_client(mock_requests, mocker)
+    mqtt_client = (
+        mock_mqtt5_client_builder.websockets_with_default_aws_signing.return_value
+    )
+    mqtt_client.publish.return_value = Mock(
+        result=Mock(side_effect=RuntimeError("aws-crt exploded"))
+    )
+
+    with pytest.raises(EmeraldConnectionError) as exc_info:
+        client.turnOn(HWS_ID)
+
+    assert "aws-crt exploded" in str(exc_info.value)
+
+
+def test_subscribe_timeout_becomes_emerald_timeout_error(
+    mock_requests, mock_boto3, mock_mqtt5_client_builder, mock_auth, mock_io, mocker
+):
+    """The subscribe future is wrapped too."""
+    mqtt_client = (
+        mock_mqtt5_client_builder.websockets_with_default_aws_signing.return_value
+    )
+    mqtt_client.subscribe.return_value = Mock(
+        result=Mock(side_effect=FuturesTimeoutError())
+    )
+
+    mock_login = Mock()
+    mock_login.json.return_value = MOCK_LOGIN_RESPONSE
+    mock_requests.post.return_value = mock_login
+    mock_properties = Mock()
+    mock_properties.json.return_value = MOCK_PROPERTY_RESPONSE_SELF
+    mock_requests.get.return_value = mock_properties
+
+    client = EmeraldHWS("test@example.com", "password")
+    mark_connected(client, mocker)
+
+    with pytest.raises(EmeraldTimeoutError) as exc_info:
+        client.connect()
+
+    assert isinstance(exc_info.value, TimeoutError)
+    assert HWS_ID in str(exc_info.value)
+    # Setup did not complete, so a later call will retry it.
+    assert not client._setup_complete
+
+
+def test_missing_hws_raises_typed_error(
+    mock_requests, mock_boto3, mock_mqtt5_client_builder, mock_auth, mock_io, mocker
+):
+    """The unknown-device error is typed, with its message preserved."""
+    client = _connected_client(mock_requests, mocker)
+
+    with pytest.raises(EmeraldError) as exc_info:
+        client.turnOn("no-such-hws")
+
+    assert "Unable to find HWS" in str(exc_info.value)
+
+
+def test_keep_alive_interval_is_sixty_seconds(
+    mock_requests, mock_boto3, mock_mqtt5_client_builder, mock_auth, mock_io, mocker
+):
+    """The aws-crt default is 20 minutes, which lets a half-open socket go
+    undetected for that long. AWS IoT accepts 30-1200s."""
+    _connected_client(mock_requests, mocker)
+
+    kwargs = mock_mqtt5_client_builder.websockets_with_default_aws_signing.call_args[1]
+    assert kwargs["keep_alive_interval_sec"] == 60
+
+
+def test_exception_hierarchy():
+    """EmeraldTimeoutError must keep subclassing the builtin TimeoutError -
+    the consuming integration catches that before its broad Exception arm."""
+    assert issubclass(EmeraldConnectionError, EmeraldError)
+    assert issubclass(EmeraldTimeoutError, EmeraldError)
+    assert issubclass(EmeraldTimeoutError, TimeoutError)
+    assert not issubclass(EmeraldConnectionError, TimeoutError)
+    # Everything stays catchable by callers using broad `except Exception`.
+    assert issubclass(EmeraldError, Exception)

--- a/tests/test_connection_gating.py
+++ b/tests/test_connection_gating.py
@@ -2,8 +2,9 @@
 
 Regression cover for the bug where a control message sent during a live
 disconnect went into the mqtt5 client's offline queue and, at QoS 1, blocked
-the caller for the full 20s publish timeout before raising a bare TimeoutError
-- with the command never delivered.
+the caller for the full 20s publish timeout before raising a bare TimeoutError.
+The command was not dropped either: awscrt re-queues un-acked QoS 1 publishes,
+so it could still arrive long after the caller was told it had failed.
 
 The guard that was supposed to prevent this read _setup_complete (then named
 _is_connected), which is deliberately never cleared on a transient disconnect,
@@ -48,18 +49,21 @@ def _connected_client(mock_requests, mocker):
     return client
 
 
-def _simulate_disconnect(client, mocker, comes_back=False):
+def _simulate_disconnect(client, mocker, wait_results=(False, False)):
     """Simulate a live disconnect: socket down, setup still complete.
 
     This is the state on_lifecycle_disconnection leaves behind - it clears
     _connection_event but deliberately leaves _setup_complete True.
 
-    :param comes_back: whether the subsequent wait() should report success
-    :returns: the patched wait mock, for asserting the timeout used
+    :param wait_results: what each successive _connection_event.wait() returns.
+        The gate waits once to give awscrt's auto-reconnect a chance, and again
+        after its own reconnect, so (False, True) means "awscrt did not recover
+        but our reconnect worked".
+    :returns: the patched wait mock, for asserting call count and timeout
     """
     mocker.patch.object(client._connection_event, "is_set", return_value=False)
     return mocker.patch.object(
-        client._connection_event, "wait", return_value=comes_back
+        client._connection_event, "wait", side_effect=list(wait_results)
     )
 
 
@@ -67,8 +71,8 @@ def test_control_message_during_disconnect_reconnects_and_fails_fast(
     mock_requests, mock_boto3, mock_mqtt5_client_builder, mock_auth, mock_io, mocker
 ):
     """The headline case: a control message sent while disconnected must
-    trigger a reconnect and raise a typed error, not block for 20s in the
-    offline queue waiting for a PUBACK that will never arrive."""
+    trigger a reconnect and raise a typed error, rather than go into the
+    offline queue to block for 20s and then possibly be delivered late."""
     client = _connected_client(mock_requests, mocker)
     mqtt_client = (
         mock_mqtt5_client_builder.websockets_with_default_aws_signing.return_value
@@ -84,15 +88,20 @@ def test_control_message_during_disconnect_reconnects_and_fails_fast(
 
     # Reconnects via reconnectMQTT, NOT connect() - connect() would stand up a
     # competing MQTT connection with duplicate timers.
-    reconnect.assert_called_once_with(reason="control_message")
+    reconnect.assert_called_once_with(reason="control_message", skip_if_connected=True)
 
     # Nothing was handed to the offline queue.
     mqtt_client.publish.assert_not_called()
 
     assert "MQTT connection unavailable" in str(exc_info.value)
 
-    # The wait is bounded at 5s, not the 20s publish timeout it replaces.
-    wait_mock.assert_called_once_with(timeout=5)
+    # Waits once before reconnecting and once after, each bounded at 5s -
+    # never the 20s publish timeout this replaces.
+    assert wait_mock.call_count == 2
+    assert wait_mock.call_args_list == [
+        mocker.call(timeout=5),
+        mocker.call(timeout=5),
+    ]
     assert elapsed < 5
 
 
@@ -115,19 +124,19 @@ def test_control_message_publishes_normally_when_connected(
 def test_control_message_publishes_after_successful_reconnect(
     mock_requests, mock_boto3, mock_mqtt5_client_builder, mock_auth, mock_io, mocker
 ):
-    """When the reconnect brings the connection back, the publish goes ahead
-    with an unchanged payload."""
+    """awscrt did not recover on its own, but our reconnect worked - the
+    publish goes ahead with an unchanged payload."""
     client = _connected_client(mock_requests, mocker)
     mqtt_client = (
         mock_mqtt5_client_builder.websockets_with_default_aws_signing.return_value
     )
 
-    _simulate_disconnect(client, mocker, comes_back=True)
+    _simulate_disconnect(client, mocker, wait_results=(False, True))
     reconnect = mocker.patch.object(client, "reconnectMQTT")
 
     client.turnOn(HWS_ID)
 
-    reconnect.assert_called_once_with(reason="control_message")
+    reconnect.assert_called_once_with(reason="control_message", skip_if_connected=True)
     mqtt_client.publish.assert_called_once()
 
     publish_packet = mqtt_client.publish.call_args[0][0]
@@ -136,6 +145,29 @@ def test_control_message_publishes_after_successful_reconnect(
     assert header["command"] == "control"
     assert header["device_id"] == HWS_ID
     assert payload == {"switch": 1}
+
+
+def test_transient_blip_is_ridden_out_without_tearing_down_the_client(
+    mock_requests, mock_boto3, mock_mqtt5_client_builder, mock_auth, mock_io, mocker
+):
+    """A brief drop clears _connection_event, but awscrt is already
+    auto-reconnecting with backoff. The gate must wait for that rather than
+    stop() the client mid-recovery and force a full rebuild."""
+    client = _connected_client(mock_requests, mocker)
+    mqtt_client = (
+        mock_mqtt5_client_builder.websockets_with_default_aws_signing.return_value
+    )
+    mqtt_client.stop.reset_mock()
+
+    wait_mock = _simulate_disconnect(client, mocker, wait_results=(True,))
+    reconnect = mocker.patch.object(client, "reconnectMQTT")
+
+    client.turnOn(HWS_ID)
+
+    wait_mock.assert_called_once_with(timeout=5)
+    reconnect.assert_not_called()
+    mqtt_client.stop.assert_not_called()
+    mqtt_client.publish.assert_called_once()
 
 
 def test_status_update_during_disconnect_does_not_reconnect(
@@ -149,12 +181,13 @@ def test_status_update_during_disconnect_does_not_reconnect(
         mock_mqtt5_client_builder.websockets_with_default_aws_signing.return_value
     )
 
-    _simulate_disconnect(client, mocker)
+    wait_mock = _simulate_disconnect(client, mocker, wait_results=(False,))
     reconnect = mocker.patch.object(client, "reconnectMQTT")
 
     with pytest.raises(EmeraldConnectionError):
         client.requestStatusUpdate(HWS_ID)
 
+    wait_mock.assert_called_once_with(timeout=5)
     reconnect.assert_not_called()
     mqtt_client.publish.assert_not_called()
 
@@ -275,6 +308,100 @@ def test_keep_alive_interval_is_sixty_seconds(
 
     kwargs = mock_mqtt5_client_builder.websockets_with_default_aws_signing.call_args[1]
     assert kwargs["keep_alive_interval_sec"] == 60
+
+
+def test_reconnect_is_skipped_if_connection_restored_while_waiting_for_lock(
+    mock_requests, mock_boto3, mock_mqtt5_client_builder, mock_auth, mock_io, mocker
+):
+    """Several threads can observe the same disconnect and queue on _mqtt_lock.
+    The second one must not stop the healthy client the first just built - a
+    QoS 1 publish already in flight on it would never get its PUBACK."""
+    client = _connected_client(mock_requests, mocker)
+    mqtt_client = (
+        mock_mqtt5_client_builder.websockets_with_default_aws_signing.return_value
+    )
+    mqtt_client.stop.reset_mock()
+
+    # is_set() is True: the connection came back before we got the lock.
+    client.reconnectMQTT(reason="control_message", skip_if_connected=True)
+
+    mqtt_client.stop.assert_not_called()
+
+
+def test_scheduled_reconnect_still_rebuilds_a_healthy_connection(
+    mock_requests, mock_boto3, mock_mqtt5_client_builder, mock_auth, mock_io, mocker
+):
+    """The skip must be opt-in: the 12-hourly refresh and the health check
+    rebuild deliberately, while the connection is up."""
+    client = _connected_client(mock_requests, mocker)
+    mqtt_client = (
+        mock_mqtt5_client_builder.websockets_with_default_aws_signing.return_value
+    )
+    mqtt_client.stop.reset_mock()
+
+    client.reconnectMQTT(reason="scheduled")
+
+    mqtt_client.stop.assert_called_once()
+
+
+def test_failed_reconnect_raises_typed_error(
+    mock_requests, mock_boto3, mock_mqtt5_client_builder, mock_auth, mock_io, mocker
+):
+    """connectMQTT makes live Cognito calls, which are likely to fail during
+    the outage that triggered the gate. Callers must not see botocore types."""
+    client = _connected_client(mock_requests, mocker)
+
+    _simulate_disconnect(client, mocker, wait_results=(False,))
+    mocker.patch.object(
+        client,
+        "reconnectMQTT",
+        side_effect=RuntimeError("botocore: could not connect to endpoint"),
+    )
+
+    with pytest.raises(EmeraldConnectionError) as exc_info:
+        client.turnOn(HWS_ID)
+
+    assert "Unable to reconnect to MQTT" in str(exc_info.value)
+    assert isinstance(exc_info.value, EmeraldError)
+
+
+def test_scheduled_reconnect_reschedules_itself_after_a_failure(
+    mock_requests, mock_boto3, mock_mqtt5_client_builder, mock_auth, mock_io, mocker
+):
+    """A failed reconnect must never kill the timer - without the reschedule
+    the process would never reconnect again for the rest of its life."""
+    client = _connected_client(mock_requests, mocker)
+    mocker.patch.object(
+        client, "reconnectMQTT", side_effect=RuntimeError("network unreachable")
+    )
+    client.reconnect_timer = None
+
+    client.scheduled_reconnect()
+
+    assert client.reconnect_timer is not None
+    assert client.reconnect_timer.is_alive()
+    client.reconnect_timer.cancel()
+
+
+def test_health_check_reschedules_itself_after_a_failed_reconnect(
+    mock_requests, mock_boto3, mock_mqtt5_client_builder, mock_auth, mock_io, mocker
+):
+    """Same for the health check, which is the shorter of the two timers and
+    so the one recovery normally depends on."""
+    client = _connected_client(mock_requests, mocker)
+    mocker.patch.object(
+        client, "reconnectMQTT", side_effect=RuntimeError("network unreachable")
+    )
+    # Force the "no messages for too long, reconnect" branch.
+    client.last_message_time = time.time() - (client.health_check_interval + 1)
+    client.connection_state = "connected"
+    client.health_check_timer = None
+
+    client.check_connection_health()
+
+    assert client.health_check_timer is not None
+    assert client.health_check_timer.is_alive()
+    client.health_check_timer.cancel()
 
 
 def test_exception_hierarchy():

--- a/tests/test_control_operations.py
+++ b/tests/test_control_operations.py
@@ -11,6 +11,7 @@ from emerald_hws import EmeraldHWS
 from .conftest import (
     MOCK_LOGIN_RESPONSE,
     MOCK_PROPERTY_RESPONSE_SELF,
+    mark_connected,
 )
 
 
@@ -46,7 +47,7 @@ def test_control_operations_trigger_mqtt_publish(
 
     # Create and connect client
     client = EmeraldHWS("test@example.com", "password")
-    mocker.patch.object(client._connection_event, "wait", return_value=True)
+    mark_connected(client, mocker)
     client.connect()
 
     hws_id = "hws-1111-aaaa-2222-bbbb"
@@ -77,9 +78,9 @@ def test_control_operation_auto_connects_when_disconnected(
 
     # Create client but DON'T connect
     client = EmeraldHWS("test@example.com", "password")
-    mocker.patch.object(client._connection_event, "wait", return_value=True)
+    mark_connected(client, mocker)
 
-    assert not client._is_connected
+    assert not client._setup_complete
 
     hws_id = "hws-1111-aaaa-2222-bbbb"
 
@@ -87,7 +88,7 @@ def test_control_operation_auto_connects_when_disconnected(
     client.turnOn(hws_id)
 
     # Verify connection was established
-    assert client._is_connected
+    assert client._setup_complete
 
     # Verify MQTT publish was called
     mqtt_client = (

--- a/tests/test_control_payload_verification.py
+++ b/tests/test_control_payload_verification.py
@@ -12,6 +12,7 @@ from emerald_hws import EmeraldHWS
 from .conftest import (
     MOCK_LOGIN_RESPONSE,
     MOCK_PROPERTY_RESPONSE_SELF,
+    mark_connected,
 )
 
 
@@ -48,7 +49,7 @@ def test_control_operations_send_correct_payload(
 
     # Create and connect client
     client = EmeraldHWS("test@example.com", "password")
-    mocker.patch.object(client._connection_event, "wait", return_value=True)
+    mark_connected(client, mocker)
     client.connect()
 
     hws_id = "hws-1111-aaaa-2222-bbbb"
@@ -112,7 +113,7 @@ def test_control_message_includes_property_details(
 
     # Create and connect client
     client = EmeraldHWS("test@example.com", "password")
-    mocker.patch.object(client._connection_event, "wait", return_value=True)
+    mark_connected(client, mocker)
     client.connect()
 
     hws_id = "hws-1111-aaaa-2222-bbbb"
@@ -148,7 +149,7 @@ def test_control_message_fails_for_nonexistent_device(
 
     # Create and connect client
     client = EmeraldHWS("test@example.com", "password")
-    mocker.patch.object(client._connection_event, "wait", return_value=True)
+    mark_connected(client, mocker)
     client.connect()
 
     # Attempt control on non-existent device
@@ -179,7 +180,7 @@ def test_control_message_topic_format(
 
     # Create and connect client
     client = EmeraldHWS("test@example.com", "password")
-    mocker.patch.object(client._connection_event, "wait", return_value=True)
+    mark_connected(client, mocker)
     client.connect()
 
     hws_id = "hws-1111-aaaa-2222-bbbb"

--- a/tests/test_integration_behaviour.py
+++ b/tests/test_integration_behaviour.py
@@ -9,6 +9,7 @@ from .conftest import (
     MQTT_MSG_TEMP_UPDATE,
     MQTT_MSG_SWITCH_OFF,
     MQTT_MSG_SWITCH_ON,
+    mark_connected,
 )
 
 
@@ -32,13 +33,13 @@ def test_complete_login_to_mqtt_flow(
         callback_calls.append(True)
 
     client = EmeraldHWS("test@example.com", "password", update_callback=test_callback)
-    mocker.patch.object(client._connection_event, "wait", return_value=True)
+    mark_connected(client, mocker)
 
     # Connect - this should: login → get properties → connect MQTT → subscribe
     client.connect()
 
     # Verify the flow worked
-    assert client._is_connected
+    assert client._setup_complete
     assert len(client.properties) == 1
     assert client.properties[0]["property_type"] == "Self"
 
@@ -67,7 +68,7 @@ def test_control_command_with_mqtt_response(
 
     # Execute
     client = EmeraldHWS("test@example.com", "password")
-    mocker.patch.object(client._connection_event, "wait", return_value=True)
+    mark_connected(client, mocker)
     client.connect()
 
     hws_id = "hws-1111-aaaa-2222-bbbb"
@@ -103,12 +104,12 @@ def test_shared_property_integration_flow(
 
     # Execute flow
     client = EmeraldHWS("customer@example.com", "password")
-    mocker.patch.object(client._connection_event, "wait", return_value=True)
+    mark_connected(client, mocker)
 
     client.connect()
 
     # Verify shared property flow works
-    assert client._is_connected
+    assert client._setup_complete
     assert len(client.properties) == 1
     assert client.properties[0]["property_type"] == "Shared"
     assert client.properties[0]["heat_pump"][0]["id"] == "hws-9999-eeee-8888-ffff"
@@ -137,7 +138,7 @@ def test_mixed_properties_integration(
 
     # Execute
     client = EmeraldHWS("user@example.com", "password")
-    mocker.patch.object(client._connection_event, "wait", return_value=True)
+    mark_connected(client, mocker)
 
     client.connect()
 
@@ -178,7 +179,7 @@ def test_state_persistence_through_reconnection(
 
     # Execute
     client = EmeraldHWS("test@example.com", "password")
-    mocker.patch.object(client._connection_event, "wait", return_value=True)
+    mark_connected(client, mocker)
 
     client.connect()
     hws_id = "hws-1111-aaaa-2222-bbbb"

--- a/tests/test_query_operations.py
+++ b/tests/test_query_operations.py
@@ -11,6 +11,7 @@ from .conftest import (
     MOCK_PROPERTY_RESPONSE_SELF,
     MOCK_PROPERTY_RESPONSE_MIXED,
     MQTT_MSG_ENERGY_UPDATE,
+    mark_connected,
 )
 
 
@@ -37,7 +38,7 @@ def test_get_full_status(
     client = EmeraldHWS("test@example.com", "password")
 
     # Patch the connection event to avoid timeout
-    mocker.patch.object(client._connection_event, "wait", return_value=True)
+    mark_connected(client, mocker)
 
     client.connect()
 
@@ -75,7 +76,7 @@ def test_get_full_status_nonexistent_hws(
     client = EmeraldHWS("test@example.com", "password")
 
     # Patch the connection event to avoid timeout
-    mocker.patch.object(client._connection_event, "wait", return_value=True)
+    mark_connected(client, mocker)
 
     client.connect()
 
@@ -89,7 +90,7 @@ def test_is_on_with_numeric_switch():
     """Test isOn() with switch=1 (numeric)."""
     client = EmeraldHWS("test@example.com", "password")
     client.properties = copy.deepcopy(MOCK_PROPERTY_RESPONSE_SELF["info"]["property"])
-    client._is_connected = True
+    client._setup_complete = True
 
     # Set switch to 1
     client.properties[0]["heat_pump"][0]["last_state"]["switch"] = 1
@@ -102,7 +103,7 @@ def test_is_on_with_string_switch():
     """Test isOn() with switch='on' (string)."""
     client = EmeraldHWS("test@example.com", "password")
     client.properties = copy.deepcopy(MOCK_PROPERTY_RESPONSE_SELF["info"]["property"])
-    client._is_connected = True
+    client._setup_complete = True
 
     # Set switch to 'on'
     client.properties[0]["heat_pump"][0]["last_state"]["switch"] = "on"
@@ -115,7 +116,7 @@ def test_is_on_when_off():
     """Test isOn() returns False when switch=0."""
     client = EmeraldHWS("test@example.com", "password")
     client.properties = copy.deepcopy(MOCK_PROPERTY_RESPONSE_SELF["info"]["property"])
-    client._is_connected = True
+    client._setup_complete = True
 
     # Set switch to 0
     client.properties[0]["heat_pump"][0]["last_state"]["switch"] = 0
@@ -128,7 +129,7 @@ def test_is_heating_with_work_state():
     """Test isHeating() with work_state=1 (actively heating)."""
     client = EmeraldHWS("test@example.com", "password")
     client.properties = copy.deepcopy(MOCK_PROPERTY_RESPONSE_SELF["info"]["property"])
-    client._is_connected = True
+    client._setup_complete = True
 
     # Set work_state to 1 (heating)
     client.properties[0]["heat_pump"][0]["last_state"]["work_state"] = 1
@@ -141,7 +142,7 @@ def test_is_heating_with_work_state_idle():
     """Test isHeating() with work_state=0 (idle/off)."""
     client = EmeraldHWS("test@example.com", "password")
     client.properties = copy.deepcopy(MOCK_PROPERTY_RESPONSE_SELF["info"]["property"])
-    client._is_connected = True
+    client._setup_complete = True
 
     # Set work_state to 0 (idle)
     client.properties[0]["heat_pump"][0]["last_state"]["work_state"] = 0
@@ -154,7 +155,7 @@ def test_is_heating_with_work_state_on_not_heating():
     """Test isHeating() with work_state=2 (on but not heating)."""
     client = EmeraldHWS("test@example.com", "password")
     client.properties = copy.deepcopy(MOCK_PROPERTY_RESPONSE_SELF["info"]["property"])
-    client._is_connected = True
+    client._setup_complete = True
 
     # Set work_state to 2 (on but not heating)
     client.properties[0]["heat_pump"][0]["last_state"]["work_state"] = 2
@@ -167,7 +168,7 @@ def test_is_heating_fallback_to_device_operation_status():
     """Test isHeating() falls back to device_operation_status when work_state not available."""
     client = EmeraldHWS("test@example.com", "password")
     client.properties = copy.deepcopy(MOCK_PROPERTY_RESPONSE_SELF["info"]["property"])
-    client._is_connected = True
+    client._setup_complete = True
 
     # Remove work_state to test fallback
     client.properties[0]["heat_pump"][0]["last_state"].pop("work_state", None)
@@ -187,7 +188,7 @@ def test_get_hourly_energy_usage():
     """Test retrieving hourly energy usage."""
     client = EmeraldHWS("test@example.com", "password")
     client.properties = copy.deepcopy(MOCK_PROPERTY_RESPONSE_SELF["info"]["property"])
-    client._is_connected = True
+    client._setup_complete = True
 
     hws_id = "hws-1111-aaaa-2222-bbbb"
     result = client.getHourlyEnergyUsage(hws_id)
@@ -201,7 +202,7 @@ def test_current_mode():
     """Test retrieving current mode (0=boost, 1=normal, 2=quiet)."""
     client = EmeraldHWS("test@example.com", "password")
     client.properties = copy.deepcopy(MOCK_PROPERTY_RESPONSE_SELF["info"]["property"])
-    client._is_connected = True
+    client._setup_complete = True
 
     hws_id = "hws-1111-aaaa-2222-bbbb"
 
@@ -222,7 +223,7 @@ def test_get_info():
     """Test retrieving identifying information for a heat pump."""
     client = EmeraldHWS("test@example.com", "password")
     client.properties = copy.deepcopy(MOCK_PROPERTY_RESPONSE_SELF["info"]["property"])
-    client._is_connected = True
+    client._setup_complete = True
 
     hws_id = "hws-1111-aaaa-2222-bbbb"
     info = client.getInfo(hws_id)
@@ -239,7 +240,7 @@ def test_get_info_nonexistent_hws():
     """Test getInfo returns None for non-existent heat pump."""
     client = EmeraldHWS("test@example.com", "password")
     client.properties = copy.deepcopy(MOCK_PROPERTY_RESPONSE_SELF["info"]["property"])
-    client._is_connected = True
+    client._setup_complete = True
 
     info = client.getInfo("nonexistent-id")
     assert info is None
@@ -268,7 +269,7 @@ def test_list_hws(
     client = EmeraldHWS("test@example.com", "password")
 
     # Patch the connection event to avoid timeout
-    mocker.patch.object(client._connection_event, "wait", return_value=True)
+    mark_connected(client, mocker)
 
     client.connect()
 
@@ -302,7 +303,7 @@ def test_list_hws_multiple(
     client = EmeraldHWS("test@example.com", "password")
 
     # Patch the connection event to avoid timeout
-    mocker.patch.object(client._connection_event, "wait", return_value=True)
+    mark_connected(client, mocker)
 
     client.connect()
 
@@ -318,7 +319,7 @@ def test_get_hourly_energy_usage_returns_updated_values():
     """Test that getHourlyEnergyUsage returns updated values after MQTT message processing."""
     client = EmeraldHWS("test@example.com", "password")
     client.properties = copy.deepcopy(MOCK_PROPERTY_RESPONSE_SELF["info"]["property"])
-    client._is_connected = True
+    client._setup_complete = True
 
     hws_id = "hws-1111-aaaa-2222-bbbb"
 
@@ -343,7 +344,7 @@ def test_get_hourly_energy_usage_with_multiple_updates():
     """Test that getHourlyEnergyUsage reflects the most recent MQTT update."""
     client = EmeraldHWS("test@example.com", "password")
     client.properties = copy.deepcopy(MOCK_PROPERTY_RESPONSE_SELF["info"]["property"])
-    client._is_connected = True
+    client._setup_complete = True
 
     hws_id = "hws-1111-aaaa-2222-bbbb"
     topic = f"ep/heat_pump/from_gw/{hws_id}"
@@ -366,7 +367,7 @@ def test_get_daily_energy_usage():
     """Test retrieving daily energy usage returns appropriate value."""
     client = EmeraldHWS("test@example.com", "password")
     client.properties = copy.deepcopy(MOCK_PROPERTY_RESPONSE_SELF["info"]["property"])
-    client._is_connected = True
+    client._setup_complete = True
 
     hws_id = "hws-1111-aaaa-2222-bbbb"
     result = client.getDailyEnergyUsage(hws_id)
@@ -397,7 +398,7 @@ def test_get_daily_energy_usage_missing_date_in_data():
 
     client.properties = copy.deepcopy(MOCK_PROPERTY_RESPONSE_SELF["info"]["property"])
     client.properties[0]["heat_pump"][0]["consumption_data"] = custom_consumption
-    client._is_connected = True
+    client._setup_complete = True
 
     hws_id = "hws-1111-aaaa-2222-bbbb"
     result = client.getDailyEnergyUsage(hws_id)
@@ -410,7 +411,7 @@ def test_get_weekly_energy_usage():
     """Test retrieving weekly energy usage structure."""
     client = EmeraldHWS("test@example.com", "password")
     client.properties = copy.deepcopy(MOCK_PROPERTY_RESPONSE_SELF["info"]["property"])
-    client._is_connected = True
+    client._setup_complete = True
 
     hws_id = "hws-1111-aaaa-2222-bbbb"
     result = client.getWeeklyEnergyUsage(hws_id)
@@ -427,7 +428,7 @@ def test_get_monthly_energy_usage():
     """Test retrieving monthly energy usage returns numeric value when data exists."""
     client = EmeraldHWS("test@example.com", "password")
     client.properties = copy.deepcopy(MOCK_PROPERTY_RESPONSE_SELF["info"]["property"])
-    client._is_connected = True
+    client._setup_complete = True
 
     hws_id = "hws-1111-aaaa-2222-bbbb"
     result = client.getMonthlyEnergyUsage(hws_id)
@@ -458,7 +459,7 @@ def test_get_monthly_energy_usage_missing_month_in_data():
 
     client.properties = copy.deepcopy(MOCK_PROPERTY_RESPONSE_SELF["info"]["property"])
     client.properties[0]["heat_pump"][0]["consumption_data"] = custom_consumption
-    client._is_connected = True
+    client._setup_complete = True
 
     hws_id = "hws-1111-aaaa-2222-bbbb"
     result = client.getMonthlyEnergyUsage(hws_id)
@@ -471,7 +472,7 @@ def test_get_historical_consumption():
     """Test retrieving full historical consumption data structure."""
     client = EmeraldHWS("test@example.com", "password")
     client.properties = copy.deepcopy(MOCK_PROPERTY_RESPONSE_SELF["info"]["property"])
-    client._is_connected = True
+    client._setup_complete = True
 
     hws_id = "hws-1111-aaaa-2222-bbbb"
     result = client.getHistoricalConsumption(hws_id)
@@ -510,7 +511,7 @@ def test_get_daily_energy_usage_handles_invalid_data_gracefully():
 
     client.properties = copy.deepcopy(MOCK_PROPERTY_RESPONSE_SELF["info"]["property"])
     client.properties[0]["heat_pump"][0]["consumption_data"] = custom_consumption
-    client._is_connected = True
+    client._setup_complete = True
 
     hws_id = "hws-1111-aaaa-2222-bbbb"
     result = client.getDailyEnergyUsage(hws_id)
@@ -541,7 +542,7 @@ def test_get_monthly_energy_usage_handles_missing_month():
 
     client.properties = copy.deepcopy(MOCK_PROPERTY_RESPONSE_SELF["info"]["property"])
     client.properties[0]["heat_pump"][0]["consumption_data"] = custom_consumption
-    client._is_connected = True
+    client._setup_complete = True
 
     hws_id = "hws-1111-aaaa-2222-bbbb"
     result = client.getMonthlyEnergyUsage(hws_id)
@@ -566,7 +567,7 @@ def test_energy_methods_handle_edge_cases_gracefully():
 
     client.properties = copy.deepcopy(MOCK_PROPERTY_RESPONSE_SELF["info"]["property"])
     client.properties[0]["heat_pump"][0]["consumption_data"] = custom_consumption
-    client._is_connected = True
+    client._setup_complete = True
 
     hws_id = "hws-1111-aaaa-2222-bbbb"
 
@@ -604,7 +605,7 @@ def test_energy_methods_handle_various_date_formats_in_data():
 
     client.properties = copy.deepcopy(MOCK_PROPERTY_RESPONSE_SELF["info"]["property"])
     client.properties[0]["heat_pump"][0]["consumption_data"] = custom_consumption
-    client._is_connected = True
+    client._setup_complete = True
 
     hws_id = "hws-1111-aaaa-2222-bbbb"
 
@@ -648,7 +649,7 @@ def test_get_daily_energy_usage_day_boundary_scenario():
 
     client.properties = copy.deepcopy(MOCK_PROPERTY_RESPONSE_SELF["info"]["property"])
     client.properties[0]["heat_pump"][0]["consumption_data"] = custom_consumption
-    client._is_connected = True
+    client._setup_complete = True
 
     hws_id = "hws-1111-aaaa-2222-bbbb"
 
@@ -680,7 +681,7 @@ def _make_client(consumption_data, omit=False):
         heat_pump.pop("consumption_data", None)
     else:
         heat_pump["consumption_data"] = consumption_data
-    client._is_connected = True
+    client._setup_complete = True
     return client
 
 

--- a/tests/test_reconnection_behaviour.py
+++ b/tests/test_reconnection_behaviour.py
@@ -6,6 +6,7 @@ from emerald_hws import EmeraldHWS
 from .conftest import (
     MOCK_LOGIN_RESPONSE,
     MOCK_PROPERTY_RESPONSE_SELF,
+    mark_connected,
 )
 
 
@@ -23,16 +24,16 @@ def test_auto_connection_on_operation_when_disconnected(
 
     # Create client but don't connect
     client = EmeraldHWS("test@example.com", "password")
-    mocker.patch.object(client._connection_event, "wait", return_value=True)
+    mark_connected(client, mocker)
 
-    assert not client._is_connected
+    assert not client._setup_complete
 
     # Attempt operation - should auto-connect
     hws_id = "hws-1111-aaaa-2222-bbbb"
     client.turnOn(hws_id)
 
     # Verify auto-connection occurred
-    assert client._is_connected
+    assert client._setup_complete
     assert mock_boto3.client.called
     assert mock_mqtt5_client_builder.websockets_with_default_aws_signing.called
 
@@ -56,7 +57,7 @@ def test_status_requested_via_mqtt_during_reconnection(
 
     # Execute
     client = EmeraldHWS("test@example.com", "password")
-    mocker.patch.object(client._connection_event, "wait", return_value=True)
+    mark_connected(client, mocker)
     client.connect()
 
     mqtt_client = (
@@ -102,7 +103,7 @@ def test_status_request_failure_during_reconnection_is_non_fatal(
     mock_requests.get.return_value = mock_properties
 
     client = EmeraldHWS("test@example.com", "password")
-    mocker.patch.object(client._connection_event, "wait", return_value=True)
+    mark_connected(client, mocker)
     client.connect()
 
     # Make MQTT publish fail on reconnect (simulating MQTT issues)
@@ -118,7 +119,7 @@ def test_status_request_failure_during_reconnection_is_non_fatal(
 
     # MQTT client should still be set up and connection healthy
     assert client.mqttClient is not None
-    assert client._is_connected is True
+    assert client._setup_complete is True
 
 
 def test_status_request_exception_during_reconnection_is_non_fatal(
@@ -134,7 +135,7 @@ def test_status_request_exception_during_reconnection_is_non_fatal(
     mock_requests.get.return_value = mock_properties
 
     client = EmeraldHWS("test@example.com", "password")
-    mocker.patch.object(client._connection_event, "wait", return_value=True)
+    mark_connected(client, mocker)
     client.connect()
 
     # Make MQTT client None to simulate connection issue during status request
@@ -147,7 +148,7 @@ def test_status_request_exception_during_reconnection_is_non_fatal(
 
     # MQTT client should still be set up and connection healthy
     assert client.mqttClient is not None
-    assert client._is_connected is True
+    assert client._setup_complete is True
 
 
 def test_mqtt_subscriptions_after_reconnection(
@@ -164,7 +165,7 @@ def test_mqtt_subscriptions_after_reconnection(
 
     # Execute
     client = EmeraldHWS("test@example.com", "password")
-    mocker.patch.object(client._connection_event, "wait", return_value=True)
+    mark_connected(client, mocker)
     client.connect()
 
     # Track subscription calls
@@ -200,12 +201,12 @@ def test_disconnect_stops_mqtt_and_cancels_timers(
     mock_requests.get.return_value = mock_properties
 
     client = EmeraldHWS("test@example.com", "password")
-    mocker.patch.object(client._connection_event, "wait", return_value=True)
+    mark_connected(client, mocker)
     client.connect()
 
     # Verify timers and client are active after connect
     assert client.mqttClient is not None
-    assert client._is_connected is True
+    assert client._setup_complete is True
     assert client.reconnect_timer is not None
     assert client.health_check_timer is not None
 
@@ -220,7 +221,7 @@ def test_disconnect_stops_mqtt_and_cancels_timers(
 
     # Verify everything is cleaned up
     assert client.mqttClient is None
-    assert client._is_connected is False
+    assert client._setup_complete is False
     assert client.reconnect_timer is None
     assert client.health_check_timer is None
 
@@ -235,4 +236,4 @@ def test_disconnect_handles_missing_client_gracefully(
     client.disconnect()
 
     assert client.mqttClient is None
-    assert client._is_connected is False
+    assert client._setup_complete is False

--- a/tests/test_state_management.py
+++ b/tests/test_state_management.py
@@ -31,7 +31,7 @@ def test_concurrent_energy_method_access():
 
     client = EmeraldHWS("test@example.com", "password")
     client.properties = MOCK_PROPERTY_RESPONSE_SELF["info"]["property"]
-    client._is_connected = True
+    client._setup_complete = True
 
     hws_id = "hws-1111-aaaa-2222-bbbb"
 
@@ -106,7 +106,7 @@ def test_concurrent_energy_updates_and_reads():
 
     client = EmeraldHWS("test@example.com", "password")
     client.properties = copy.deepcopy(MOCK_PROPERTY_RESPONSE_SELF["info"]["property"])
-    client._is_connected = True
+    client._setup_complete = True
 
     hws_id = "hws-1111-aaaa-2222-bbbb"
     topic = f"ep/heat_pump/from_gw/{hws_id}"
@@ -266,7 +266,7 @@ def test_mqtt_state_reflected_in_queries():
     """Test that MQTT updates are immediately reflected in query methods."""
     client = EmeraldHWS("test@example.com", "password")
     client.properties = copy.deepcopy(MOCK_PROPERTY_RESPONSE_SELF["info"]["property"])
-    client._is_connected = True
+    client._setup_complete = True
 
     hws_id = "hws-1111-aaaa-2222-bbbb"
 
@@ -294,7 +294,7 @@ def test_heating_state_updates_consistency():
     """Test that heating state updates are consistent between MQTT and fallback logic."""
     client = EmeraldHWS("test@example.com", "password")
     client.properties = copy.deepcopy(MOCK_PROPERTY_RESPONSE_SELF["info"]["property"])
-    client._is_connected = True
+    client._setup_complete = True
 
     hws_id = "hws-1111-aaaa-2222-bbbb"
 


### PR DESCRIPTION
## Summary by Sourcery

Refine MQTT connection lifecycle handling to avoid dropped control and status messages during transient disconnects, introduce typed Emerald-specific exceptions for connection and timeout failures, and extend tests to cover connection gating and error propagation behaviours.

Bug Fixes:
- Prevent control and status MQTT messages from being silently queued and timing out when sent during a live disconnect by gating operations on real connection state instead of setup completion flags.
- Ensure timeouts and transport failures from MQTT publish/subscribe operations raise explicit EmeraldTimeoutError or EmeraldConnectionError rather than leaking raw exceptions.

Enhancements:
- Separate initial setup completion from live connection state via a dedicated _setup_complete flag and a connection event gate, improving reconnection and auto-connect behaviour.
- Reduce MQTT keep-alive interval to 60 seconds so half-open sockets are detected more quickly by AWS IoT.
- Expose EmeraldError, EmeraldConnectionError, and EmeraldTimeoutError at the package level to give callers a stable exception surface.

Tests:
- Add comprehensive connection gating test coverage for control and status operations, reconnect behaviour, keep-alive configuration, and the custom exception hierarchy.
- Update existing tests and shared fixtures to work with the new _setup_complete flag and connection event handling.