### PR TITLE
fix: disable metrics, avoiding certificate library mismatches

### DIFF
--- a/src/emerald_hws/emeraldhws.py
+++ b/src/emerald_hws/emeraldhws.py
@@ -358,6 +358,17 @@ class EmeraldHWS:
                 # socket can go undetected for that long. AWS IoT accepts
                 # 30-1200 seconds; 60 gets a dead socket noticed in ~60-90s.
                 keep_alive_interval_sec=60,
+                # Skip aws-crt's IoT usage-metrics path. It only reports the SDK
+                # name and version in the CONNECT username, but since awscrt
+                # 0.35.0 building it reads ClientTlsContext._certificate_source -
+                # a slot only that release's awscrt.io declares. Home Assistant
+                # imports awscrt during startup (cloud -> botocore) and then
+                # upgrades it on disk when installing this library, so the new
+                # metrics code can meet the old cached class and every connect()
+                # fails for the life of the process. Disabling it also keeps the
+                # native mqtt5_client_new metrics arguments at (False, None),
+                # which every awscrt accepts. Supported since awsiotsdk 1.24.0.
+                enable_metrics_collection=False,
             )
 
             client.start()

--- a/src/emerald_hws/emeraldhws.py
+++ b/src/emerald_hws/emeraldhws.py
@@ -358,16 +358,10 @@ class EmeraldHWS:
                 # socket can go undetected for that long. AWS IoT accepts
                 # 30-1200 seconds; 60 gets a dead socket noticed in ~60-90s.
                 keep_alive_interval_sec=60,
-                # Skip aws-crt's IoT usage-metrics path. It only reports the SDK
-                # name and version in the CONNECT username, but since awscrt
-                # 0.35.0 building it reads ClientTlsContext._certificate_source -
-                # a slot only that release's awscrt.io declares. Home Assistant
-                # imports awscrt during startup (cloud -> botocore) and then
-                # upgrades it on disk when installing this library, so the new
-                # metrics code can meet the old cached class and every connect()
-                # fails for the life of the process. Disabling it also keeps the
-                # native mqtt5_client_new metrics arguments at (False, None),
-                # which every awscrt accepts. Supported since awsiotsdk 1.24.0.
+                # Skip aws-crt's IoT usage-metrics path: it only reports the SDK
+                # name and version, and building it breaks outright when two
+                # awscrt versions are loaded at once. Supported since awsiotsdk
+                # 1.24.0. See tests/test_native_bindings.py for the full rationale.
                 enable_metrics_collection=False,
             )
 

--- a/tests/test_connection_gating.py
+++ b/tests/test_connection_gating.py
@@ -315,11 +315,8 @@ def test_iot_metrics_collection_is_disabled(
 ):
     """awscrt's usage-metrics path must stay off.
 
-    Since awscrt 0.35.0, building it reads ClientTlsContext._certificate_source -
-    a slot only that release's awscrt.io declares. Home Assistant imports awscrt
-    during startup (cloud -> hass_nabucasa -> botocore) and then upgrades it on
-    disk when installing this library, so the freshly loaded metrics code can
-    meet the old cached class and every connect() fails until HA is restarted.
+    Building it breaks outright when two awscrt versions are loaded at once; see
+    tests/test_native_bindings.py for why that happens under Home Assistant.
     """
     _connected_client(mock_requests, mocker)
 

--- a/tests/test_connection_gating.py
+++ b/tests/test_connection_gating.py
@@ -310,6 +310,23 @@ def test_keep_alive_interval_is_sixty_seconds(
     assert kwargs["keep_alive_interval_sec"] == 60
 
 
+def test_iot_metrics_collection_is_disabled(
+    mock_requests, mock_boto3, mock_mqtt5_client_builder, mock_auth, mock_io, mocker
+):
+    """awscrt's usage-metrics path must stay off.
+
+    Since awscrt 0.35.0, building it reads ClientTlsContext._certificate_source -
+    a slot only that release's awscrt.io declares. Home Assistant imports awscrt
+    during startup (cloud -> hass_nabucasa -> botocore) and then upgrades it on
+    disk when installing this library, so the freshly loaded metrics code can
+    meet the old cached class and every connect() fails until HA is restarted.
+    """
+    _connected_client(mock_requests, mocker)
+
+    kwargs = mock_mqtt5_client_builder.websockets_with_default_aws_signing.call_args[1]
+    assert kwargs["enable_metrics_collection"] is False
+
+
 def test_reconnect_is_skipped_if_connection_restored_while_waiting_for_lock(
     mock_requests, mock_boto3, mock_mqtt5_client_builder, mock_auth, mock_io, mocker
 ):

--- a/tests/test_native_bindings.py
+++ b/tests/test_native_bindings.py
@@ -1,14 +1,33 @@
-"""Regression test for awscrt Python-wrapper vs native _awscrt.so drift.
+"""Regression tests for awscrt version drift.
 
-Background: a fresh HA install once failed at connect with
-    "function takes exactly 43 arguments (45 given)"
-because an in-place HAOS upgrade left a stale compiled _awscrt*.so (old native,
-43 args) under a newer pure-Python awscrt wrapper (45 args). The version graph
-stays consistent (awsiotsdk pins awscrt exactly), so the skew is purely between
-the .py wrapper and the .so on disk.
+This module docstring is the canonical explanation of the problem; the code that
+guards against it (`connectMQTT`) and the tests below refer here rather than
+repeating it.
+
+awscrt is a compiled extension whose Python files and native library have to
+match, and it moves whenever awsiotsdk does. Two field failures came from halves
+of different versions meeting inside one process:
+
+  - `function takes exactly 43 arguments (45 given)` -- a stale compiled
+    _awscrt*.so (43 args) under a newer pure-Python wrapper (45 args), left by an
+    in-place HAOS upgrade. The two arguments accounting for the difference are
+    the metrics pair awscrt 0.32.2 added to mqtt5_client_new.
+  - `'ClientTlsContext' object has no attribute '_certificate_source'` -- a slot
+    only awscrt >=0.35.0's awscrt.io declares, but which >=0.35.0's usage-metrics
+    code reads unconditionally. Home Assistant loads awscrt during startup
+    (`cloud` -> hass_nabucasa -> botocore, whose compat module imports it) and
+    then upgrades it on disk while installing this library, so modules imported
+    afterwards can meet the old cached class. The stale modules stay in
+    sys.modules for the lifetime of the process, so only a restart clears it.
+
+connectMQTT passes `enable_metrics_collection=False`, which skips the metrics
+code path entirely and pins the two native metrics arguments to (False, None) --
+values every awscrt release accepts. That makes the second failure unreachable.
+The first is a genuine wrapper/extension arity mismatch that no Python-level flag
+can bridge, since those arguments are passed positionally either way.
 
 Building (not starting) an mqtt5 client invokes the native
-_awscrt.mqtt5_client_new binding at construction time, so it detects that skew
+_awscrt.mqtt5_client_new binding at construction time, so these tests cross it
 without any network or credentials.
 """
 
@@ -16,25 +35,33 @@ import pytest
 from awscrt import auth
 from awsiot import mqtt5_client_builder
 
+# RFC 2606 reserves .invalid, so this name can never resolve. No .start() is
+# called either, so nothing here opens a socket regardless -- but a
+# guaranteed-dead endpoint removes any doubt about external dependencies.
+FAKE_ENDPOINT = "mqtt.example.invalid"
+FAKE_REGION = "ap-southeast-2"
+
+
+def _fake_credentials():
+    """Throwaway static credentials, never used to sign a real request."""
+    return auth.AwsCredentialsProvider.new_static(
+        access_key_id="AKIDEXAMPLE",
+        secret_access_key="secret",
+    )
+
 
 def test_awscrt_wrapper_native_arity_in_sync():
     """Build an mqtt5 client offline to cross the awscrt native binding.
 
-    websockets_with_default_aws_signing constructs awscrt.mqtt5.Client at build
-    time, whose __init__ calls the native _awscrt.mqtt5_client_new. No .start()
-    is called, so no socket is opened. If the installed awscrt .py wrapper and
-    compiled _awscrt extension disagree on arg count, construction raises a
-    native TypeError -- exactly the failure seen in the field.
+    If the installed awscrt .py wrapper and compiled _awscrt extension disagree
+    on argument count, construction raises a native TypeError -- the first
+    failure described in the module docstring.
     """
-    creds = auth.AwsCredentialsProvider.new_static(
-        access_key_id="AKIDEXAMPLE",
-        secret_access_key="secret",
-    )
     try:
         client = mqtt5_client_builder.websockets_with_default_aws_signing(
-            endpoint="example-ats.iot.ap-southeast-2.amazonaws.com",
-            region="ap-southeast-2",
-            credentials_provider=creds,
+            endpoint=FAKE_ENDPOINT,
+            region=FAKE_REGION,
+            credentials_provider=_fake_credentials(),
         )  # builds Client -> _awscrt.mqtt5_client_new; no .start(), no network
     except TypeError as e:
         pytest.fail(
@@ -47,22 +74,15 @@ def test_awscrt_wrapper_native_arity_in_sync():
 
 
 def test_metrics_disabled_build_crosses_native_binding():
-    """Build offline the way connectMQTT does, with metrics collection off.
+    """Build the way connectMQTT does, with metrics collection off.
 
-    This is the production kwarg combination, so it is the one worth exercising
-    against the real awscrt. Disabling metrics makes awscrt.mqtt5 skip
-    _create_metrics_mqtt5 (which since 0.35.0 reads the private
-    ClientTlsContext._certificate_source) and pass (False, None) for the two
-    native metrics arguments -- values every awscrt release accepts.
+    This is the production keyword combination, so it is the one worth exercising
+    against the real awscrt. See the module docstring for why metrics are off.
     """
-    creds = auth.AwsCredentialsProvider.new_static(
-        access_key_id="AKIDEXAMPLE",
-        secret_access_key="secret",
-    )
     client = mqtt5_client_builder.websockets_with_default_aws_signing(
-        endpoint="example-ats.iot.ap-southeast-2.amazonaws.com",
-        region="ap-southeast-2",
-        credentials_provider=creds,
+        endpoint=FAKE_ENDPOINT,
+        region=FAKE_REGION,
+        credentials_provider=_fake_credentials(),
         enable_metrics_collection=False,
     )  # builds Client -> _awscrt.mqtt5_client_new; no .start(), no network
 

--- a/tests/test_native_bindings.py
+++ b/tests/test_native_bindings.py
@@ -44,3 +44,26 @@ def test_awscrt_wrapper_native_arity_in_sync():
             "upgrade. Fix: pip install --force-reinstall --no-cache-dir awscrt"
         )
     assert client is not None
+
+
+def test_metrics_disabled_build_crosses_native_binding():
+    """Build offline the way connectMQTT does, with metrics collection off.
+
+    This is the production kwarg combination, so it is the one worth exercising
+    against the real awscrt. Disabling metrics makes awscrt.mqtt5 skip
+    _create_metrics_mqtt5 (which since 0.35.0 reads the private
+    ClientTlsContext._certificate_source) and pass (False, None) for the two
+    native metrics arguments -- values every awscrt release accepts.
+    """
+    creds = auth.AwsCredentialsProvider.new_static(
+        access_key_id="AKIDEXAMPLE",
+        secret_access_key="secret",
+    )
+    client = mqtt5_client_builder.websockets_with_default_aws_signing(
+        endpoint="example-ats.iot.ap-southeast-2.amazonaws.com",
+        region="ap-southeast-2",
+        credentials_provider=creds,
+        enable_metrics_collection=False,
+    )  # builds Client -> _awscrt.mqtt5_client_new; no .start(), no network
+
+    assert client is not None


### PR DESCRIPTION
## Summary by Sourcery

Disable AWS IoT MQTT usage-metrics collection to avoid incompatibilities with differing awscrt versions and ensure stable connections in Home Assistant environments.

Bug Fixes:
- Ensure MQTT clients are built with metrics collection disabled to prevent runtime failures when awscrt is upgraded while an older version remains cached.

Tests:
- Add tests to verify MQTT client construction with metrics disabled and to confirm the production connection path does not enable awscrt usage metrics.