### PR TITLE
feat: refresh on connect

### DIFF
--- a/src/emerald_hws/emeraldhws.py
+++ b/src/emerald_hws/emeraldhws.py
@@ -59,6 +59,10 @@ class EmeraldHWS:
         self._mqtt_lock = (
             threading.RLock()
         )  # Lock to protect MQTT client lifecycle operations
+        # Held for the duration of a status refresh. Non-reentrant and only
+        # ever acquired non-blocking, so overlapping refreshes collapse into
+        # one - see _request_status_updates_safe.
+        self._status_refresh_lock = threading.Lock()
         # Tracks whether connect() has finished its full setup (login, HWS
         # discovery, MQTT, subscriptions, timers). This is NOT a measure of
         # whether the socket is currently up - transient disconnects leave it
@@ -300,13 +304,44 @@ class EmeraldHWS:
             raise EmeraldConnectionError("MQTT connection unavailable")
 
     def _request_status_updates_safe(self):
-        """Request status updates from all HWS, logging any failures."""
+        """Request status updates from all HWS, logging any failures.
+
+        Best-effort by design: three separate paths call this (initial connect,
+        reconnectMQTT, and on_connection_resumed), so it must never raise into
+        any of them, and it must tolerate being called while another refresh is
+        already running.
+
+        The non-blocking lock is what makes that safe. It is a plain Lock, not
+        an RLock, on purpose: requestAllStatusUpdates fans out over a thread
+        pool and each worker calls getFullStatus, which calls connect() if
+        setup was torn down underneath it - and connect() ends by calling this
+        method again. A re-entrant lock would let that recurse, one nested
+        thread pool per worker. Failing the acquire instead makes the nested
+        call a no-op, and skipping is correct: the refresh already in flight
+        covers the same devices.
+        """
+        if not self._status_refresh_lock.acquire(blocking=False):
+            self.logger.debug(
+                "emeraldhws: awsiot: Status refresh already in progress, skipping"
+            )
+            return
+
         try:
+            # connect() releases _connect_lock before calling this, so a
+            # disconnect() can land in between and pull the client out from
+            # under us. Nothing to ask, and no client to ask over.
+            if self.mqttClient is None or not self._setup_complete:
+                self.logger.debug(
+                    "emeraldhws: awsiot: Skipping status refresh, MQTT setup not complete"
+                )
+                return
             self.requestAllStatusUpdates()
         except Exception as e:
             self.logger.warning(
                 f"emeraldhws: awsiot: Failed to request status updates: {e}"
             )
+        finally:
+            self._status_refresh_lock.release()
 
     def connectMQTT(self):
         """Establishes a connection to Amazon IOT core's MQTT service"""

--- a/src/emerald_hws/emeraldhws.py
+++ b/src/emerald_hws/emeraldhws.py
@@ -4,6 +4,7 @@ import random
 import threading
 import time
 from concurrent.futures import TimeoutError as FuturesTimeoutError
+from contextlib import contextmanager
 from datetime import datetime
 
 import boto3
@@ -12,6 +13,24 @@ from awscrt import mqtt5, auth, io
 from awsiot import mqtt5_client_builder
 
 from .exceptions import EmeraldConnectionError, EmeraldError, EmeraldTimeoutError
+
+
+@contextmanager
+def _try_acquire(lock):
+    """Acquire lock without blocking, yielding whether it was taken.
+
+    Releases on the way out only if this block is what acquired it, so an
+    early return or a raise inside the body cannot leak the lock, and a body
+    that never got it cannot release someone else's hold. That last part is
+    why this tracks a flag rather than checking lock.locked() on exit -
+    locked() cannot distinguish our hold from another thread's.
+    """
+    acquired = lock.acquire(blocking=False)
+    try:
+        yield acquired
+    finally:
+        if acquired:
+            lock.release()
 
 
 class EmeraldHWS:
@@ -320,28 +339,32 @@ class EmeraldHWS:
         call a no-op, and skipping is correct: the refresh already in flight
         covers the same devices.
         """
-        if not self._status_refresh_lock.acquire(blocking=False):
-            self.logger.debug(
-                "emeraldhws: awsiot: Status refresh already in progress, skipping"
-            )
-            return
-
-        try:
-            # connect() releases _connect_lock before calling this, so a
-            # disconnect() can land in between and pull the client out from
-            # under us. Nothing to ask, and no client to ask over.
-            if self.mqttClient is None or not self._setup_complete:
+        with _try_acquire(self._status_refresh_lock) as acquired:
+            if not acquired:
                 self.logger.debug(
-                    "emeraldhws: awsiot: Skipping status refresh, MQTT setup not complete"
+                    "emeraldhws: awsiot: Status refresh already in progress, skipping"
                 )
                 return
-            self.requestAllStatusUpdates()
-        except Exception as e:
-            self.logger.warning(
-                f"emeraldhws: awsiot: Failed to request status updates: {e}"
-            )
-        finally:
-            self._status_refresh_lock.release()
+
+            try:
+                # connect() releases _connect_lock before calling this, so a
+                # disconnect() can land in between and pull the client out from
+                # under us. Nothing to ask, and no client to ask over.
+                if self.mqttClient is None or not self._setup_complete:
+                    self.logger.debug(
+                        "emeraldhws: awsiot: Skipping status refresh, MQTT setup not complete"
+                    )
+                    return
+                self.requestAllStatusUpdates()
+            except Exception as e:
+                # Traceback included: this swallows the only view callers get
+                # of a fan-out failure, and the interesting ones are
+                # intermittent. Stays at warning rather than logger.exception's
+                # error - the refresh is best-effort and the client is fine.
+                self.logger.warning(
+                    f"emeraldhws: awsiot: Failed to request status updates: {e}",
+                    exc_info=True,
+                )
 
     def connectMQTT(self):
         """Establishes a connection to Amazon IOT core's MQTT service"""

--- a/src/emerald_hws/emeraldhws.py
+++ b/src/emerald_hws/emeraldhws.py
@@ -1136,6 +1136,14 @@ class EmeraldHWS:
                 self.health_check_timer.daemon = True
                 self.health_check_timer.start()
 
+        # Seed state from MQTT rather than the REST snapshot, which lags behind
+        # what the device reports. Mirrors reconnectMQTT, which does the same
+        # after resubscribing. Outside _connect_lock: requestStatusUpdate fans
+        # out over a thread pool and each worker calls getFullStatus, which
+        # calls connect() if setup is incomplete - and _connect_lock is a plain
+        # Lock, so re-entering it would deadlock.
+        self._request_status_updates_safe()
+
     def disconnect(self):
         """Disconnect MQTT client and cancel all background timers.
         Should be called when the integration is being unloaded to prevent

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -393,8 +393,12 @@ def connect_and_clear_publishes(client, expected_comp_queries=1):
     assert on a later publish - a control message, an explicit status request -
     care only about that one, so drop the startup calls from the mock.
 
-    The burst is checked before it is dropped, so that a connect() which grew
-    an unexpected extra publish fails here rather than being swallowed.
+    The burst is identified before it is dropped, so a connect() that grew an
+    unexpected extra publish fails here rather than being silently swallowed.
+    Identification only - the comp_query envelope itself is pinned in one
+    place, test_status_requested_via_mqtt_on_initial_connect. Repeating those
+    assertions here would make an envelope change break every test that merely
+    passes through this helper.
 
     :param expected_comp_queries: how many heat pumps the mocked API returns;
         defaults to 1, matching MOCK_PROPERTY_RESPONSE_SELF.
@@ -407,13 +411,11 @@ def connect_and_clear_publishes(client, expected_comp_queries=1):
         f"message(s), got {publish.call_count}: {publish.call_args_list}"
     )
     for call in publish.call_args_list:
-        packet = call[0][0]
-        header, body = json.loads(packet.payload)
+        header, _ = json.loads(call[0][0].payload)
         assert header["command"] == "comp_query", (
             f"connect() published an unexpected '{header['command']}' message"
         )
-        assert packet.topic == f"ep/heat_pump/to_gw/{header['device_id']}"
-        assert body == {}
+        assert header["device_id"], "startup comp_query is missing its device_id"
 
     publish.reset_mock()
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -385,6 +385,18 @@ def mark_connected(client, mocker):
     mocker.patch.object(client._connection_event, "is_set", return_value=True)
 
 
+def connect_and_clear_publishes(client):
+    """Run connect(), then forget the comp_query burst it sends on startup.
+
+    connect() publishes a comp_query per heat pump so initial state comes from
+    the device rather than the REST snapshot, which lags behind. Tests that
+    assert on a later publish - a control message, an explicit status request -
+    care only about that one, so drop the startup calls from the mock.
+    """
+    client.connect()
+    client.mqttClient.publish.reset_mock()
+
+
 @pytest.fixture
 def mock_requests(mocker):
     """Mock requests library for API calls."""

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -385,16 +385,37 @@ def mark_connected(client, mocker):
     mocker.patch.object(client._connection_event, "is_set", return_value=True)
 
 
-def connect_and_clear_publishes(client):
+def connect_and_clear_publishes(client, expected_comp_queries=1):
     """Run connect(), then forget the comp_query burst it sends on startup.
 
     connect() publishes a comp_query per heat pump so initial state comes from
     the device rather than the REST snapshot, which lags behind. Tests that
     assert on a later publish - a control message, an explicit status request -
     care only about that one, so drop the startup calls from the mock.
+
+    The burst is checked before it is dropped, so that a connect() which grew
+    an unexpected extra publish fails here rather than being swallowed.
+
+    :param expected_comp_queries: how many heat pumps the mocked API returns;
+        defaults to 1, matching MOCK_PROPERTY_RESPONSE_SELF.
     """
     client.connect()
-    client.mqttClient.publish.reset_mock()
+
+    publish = client.mqttClient.publish
+    assert publish.call_count == expected_comp_queries, (
+        f"connect() should publish exactly {expected_comp_queries} comp_query "
+        f"message(s), got {publish.call_count}: {publish.call_args_list}"
+    )
+    for call in publish.call_args_list:
+        packet = call[0][0]
+        header, body = json.loads(packet.payload)
+        assert header["command"] == "comp_query", (
+            f"connect() published an unexpected '{header['command']}' message"
+        )
+        assert packet.topic == f"ep/heat_pump/to_gw/{header['device_id']}"
+        assert body == {}
+
+    publish.reset_mock()
 
 
 @pytest.fixture

--- a/tests/test_connection_gating.py
+++ b/tests/test_connection_gating.py
@@ -27,6 +27,7 @@ from emerald_hws import (
 from .conftest import (
     MOCK_LOGIN_RESPONSE,
     MOCK_PROPERTY_RESPONSE_SELF,
+    connect_and_clear_publishes,
     mark_connected,
 )
 
@@ -45,7 +46,9 @@ def _connected_client(mock_requests, mocker):
 
     client = EmeraldHWS("test@example.com", "password")
     mark_connected(client, mocker)
-    client.connect()
+    # Clears the startup comp_query so these gate assertions see only the
+    # publish the test itself triggers.
+    connect_and_clear_publishes(client)
     return client
 
 

--- a/tests/test_control_operations.py
+++ b/tests/test_control_operations.py
@@ -5,12 +5,14 @@ These tests focus on basic integration - that control operations can be called
 and result in MQTT publish being invoked.
 """
 
+import json
 import pytest
 from unittest.mock import Mock
 from emerald_hws import EmeraldHWS
 from .conftest import (
     MOCK_LOGIN_RESPONSE,
     MOCK_PROPERTY_RESPONSE_SELF,
+    connect_and_clear_publishes,
     mark_connected,
 )
 
@@ -48,7 +50,7 @@ def test_control_operations_trigger_mqtt_publish(
     # Create and connect client
     client = EmeraldHWS("test@example.com", "password")
     mark_connected(client, mocker)
-    client.connect()
+    connect_and_clear_publishes(client)
 
     hws_id = "hws-1111-aaaa-2222-bbbb"
 
@@ -90,8 +92,12 @@ def test_control_operation_auto_connects_when_disconnected(
     # Verify connection was established
     assert client._setup_complete
 
-    # Verify MQTT publish was called
+    # Verify MQTT publish was called. The auto-connect happens first and sends
+    # its own comp_query, so the control message is the last publish rather
+    # than the only one.
     mqtt_client = (
         mock_mqtt5_client_builder.websockets_with_default_aws_signing.return_value
     )
-    mqtt_client.publish.assert_called_once()
+    assert mqtt_client.publish.called
+    header, _ = json.loads(mqtt_client.publish.call_args[0][0].payload)
+    assert header["command"] == "control"

--- a/tests/test_control_operations.py
+++ b/tests/test_control_operations.py
@@ -92,12 +92,20 @@ def test_control_operation_auto_connects_when_disconnected(
     # Verify connection was established
     assert client._setup_complete
 
-    # Verify MQTT publish was called. The auto-connect happens first and sends
-    # its own comp_query, so the control message is the last publish rather
-    # than the only one.
+    # Verify MQTT publish was called. The auto-connect runs first and sends its
+    # own comp_query to seed state, so the control message is the last publish
+    # rather than the only one - assert on both, so a control message that
+    # silently stopped being sent cannot pass on the comp_query alone.
     mqtt_client = (
         mock_mqtt5_client_builder.websockets_with_default_aws_signing.return_value
     )
-    assert mqtt_client.publish.called
-    header, _ = json.loads(mqtt_client.publish.call_args[0][0].payload)
-    assert header["command"] == "control"
+    commands = [
+        json.loads(call[0][0].payload)[0]["command"]
+        for call in mqtt_client.publish.call_args_list
+    ]
+    assert "comp_query" in commands[:-1], (
+        f"auto-connect should have seeded state with a comp_query, got {commands}"
+    )
+    assert commands[-1] == "control", (
+        f"the control message should be the final publish, got {commands}"
+    )

--- a/tests/test_control_operations.py
+++ b/tests/test_control_operations.py
@@ -109,3 +109,6 @@ def test_control_operation_auto_connects_when_disconnected(
     assert commands[-1] == "control", (
         f"the control message should be the final publish, got {commands}"
     )
+    assert commands.count("control") == 1, (
+        f"turnOn should publish exactly one control message, got {commands}"
+    )

--- a/tests/test_control_payload_verification.py
+++ b/tests/test_control_payload_verification.py
@@ -12,6 +12,7 @@ from emerald_hws import EmeraldHWS
 from .conftest import (
     MOCK_LOGIN_RESPONSE,
     MOCK_PROPERTY_RESPONSE_SELF,
+    connect_and_clear_publishes,
     mark_connected,
 )
 
@@ -50,7 +51,7 @@ def test_control_operations_send_correct_payload(
     # Create and connect client
     client = EmeraldHWS("test@example.com", "password")
     mark_connected(client, mocker)
-    client.connect()
+    connect_and_clear_publishes(client)
 
     hws_id = "hws-1111-aaaa-2222-bbbb"
 
@@ -114,7 +115,7 @@ def test_control_message_includes_property_details(
     # Create and connect client
     client = EmeraldHWS("test@example.com", "password")
     mark_connected(client, mocker)
-    client.connect()
+    connect_and_clear_publishes(client)
 
     hws_id = "hws-1111-aaaa-2222-bbbb"
     client.turnOn(hws_id)
@@ -150,7 +151,7 @@ def test_control_message_fails_for_nonexistent_device(
     # Create and connect client
     client = EmeraldHWS("test@example.com", "password")
     mark_connected(client, mocker)
-    client.connect()
+    connect_and_clear_publishes(client)
 
     # Attempt control on non-existent device
     with pytest.raises(Exception) as exc_info:
@@ -181,7 +182,7 @@ def test_control_message_topic_format(
     # Create and connect client
     client = EmeraldHWS("test@example.com", "password")
     mark_connected(client, mocker)
-    client.connect()
+    connect_and_clear_publishes(client)
 
     hws_id = "hws-1111-aaaa-2222-bbbb"
     client.setBoostMode(hws_id)

--- a/tests/test_reconnection_behaviour.py
+++ b/tests/test_reconnection_behaviour.py
@@ -5,9 +5,21 @@ from unittest.mock import Mock
 from emerald_hws import EmeraldHWS
 from .conftest import (
     MOCK_LOGIN_RESPONSE,
+    MOCK_PROPERTY_RESPONSE_MIXED,
     MOCK_PROPERTY_RESPONSE_SELF,
     mark_connected,
 )
+
+
+def _mock_api(mock_requests, property_response=MOCK_PROPERTY_RESPONSE_SELF):
+    """Point the mocked REST layer at a login and a property list."""
+    mock_login = Mock()
+    mock_login.json.return_value = MOCK_LOGIN_RESPONSE
+    mock_requests.post.return_value = mock_login
+
+    mock_properties = Mock()
+    mock_properties.json.return_value = property_response
+    mock_requests.get.return_value = mock_properties
 
 
 def test_auto_connection_on_operation_when_disconnected(
@@ -36,6 +48,105 @@ def test_auto_connection_on_operation_when_disconnected(
     assert client._setup_complete
     assert mock_boto3.client.called
     assert mock_mqtt5_client_builder.websockets_with_default_aws_signing.called
+
+
+def test_status_requested_via_mqtt_on_initial_connect(
+    mock_requests, mock_boto3, mock_mqtt5_client_builder, mock_auth, mock_io, mocker
+):
+    """Test that connect() sends a comp_query to every HWS it discovers.
+
+    getAllHWS() seeds last_state from the REST API, which now lags behind what
+    the device reports over MQTT. connect() therefore does what reconnectMQTT
+    already did and asks each device for its live status, so a fresh session is
+    not left showing stale values until the next unsolicited upload_status.
+    """
+    _mock_api(mock_requests, MOCK_PROPERTY_RESPONSE_MIXED)
+
+    client = EmeraldHWS("test@example.com", "password")
+    mark_connected(client, mocker)
+    client.connect()
+
+    mqtt_client = (
+        mock_mqtt5_client_builder.websockets_with_default_aws_signing.return_value
+    )
+
+    # One comp_query per heat pump - the self-owned one and the shared one.
+    expected = {
+        "hws-1111-aaaa-2222-bbbb": ("prop-aaaa-1111-bbbb-2222", "aabbccddeeff"),
+        "hws-9999-eeee-8888-ffff": ("prop-9999-eeee-8888-ffff", "112233445566"),
+    }
+    assert mqtt_client.publish.call_count == len(expected)
+
+    seen = {}
+    for call in mqtt_client.publish.call_args_list:
+        packet = call[0][0]
+        header, body = json.loads(packet.payload)
+        assert header["command"] == "comp_query"
+        assert header["direction"] == "app2gw"
+        assert header["namespace"] == "business"
+        assert body == {}
+        assert packet.topic == "ep/heat_pump/to_gw/{}".format(header["device_id"])
+        seen[header["device_id"]] = (header["property_id"], header["hw_id"])
+
+    assert seen == expected
+
+
+def test_status_not_requested_again_on_redundant_connect(
+    mock_requests, mock_boto3, mock_mqtt5_client_builder, mock_auth, mock_io, mocker
+):
+    """Test that a second connect() on a live client sends no further comp_query.
+
+    connect() is called lazily from getFullStatus/listHWS on every cold read, so
+    the refresh must sit behind the _setup_complete early return - otherwise
+    routine reads would fan out a comp_query burst each time.
+    """
+    _mock_api(mock_requests)
+
+    client = EmeraldHWS("test@example.com", "password")
+    mark_connected(client, mocker)
+    client.connect()
+
+    mqtt_client = (
+        mock_mqtt5_client_builder.websockets_with_default_aws_signing.return_value
+    )
+    assert mqtt_client.publish.call_count == 1
+    mqtt_client.publish.reset_mock()
+
+    client.connect()
+
+    mqtt_client.publish.assert_not_called()
+
+
+def test_status_request_failure_on_initial_connect_is_non_fatal(
+    mock_requests, mock_boto3, mock_mqtt5_client_builder, mock_auth, mock_io, mocker
+):
+    """Test that connect() still completes when the startup comp_query fails.
+
+    A device that is offline at startup must not stop the client being usable -
+    the refresh is best-effort, swallowed by _request_status_updates_safe.
+    """
+    _mock_api(mock_requests)
+
+    mqtt_client = (
+        mock_mqtt5_client_builder.websockets_with_default_aws_signing.return_value
+    )
+    mqtt_client.publish.return_value.result.side_effect = Exception(
+        "MQTT publish failed"
+    )
+
+    client = EmeraldHWS("test@example.com", "password")
+    mark_connected(client, mocker)
+
+    client.connect()
+
+    assert client._setup_complete is True
+    assert client.mqttClient is not None
+    # Subscriptions and timers were still set up before the failed refresh.
+    mqtt_client.subscribe.assert_called_once()
+    assert client.reconnect_timer is not None
+    assert client.health_check_timer is not None
+    client.reconnect_timer.cancel()
+    client.health_check_timer.cancel()
 
 
 def test_status_requested_via_mqtt_during_reconnection(

--- a/tests/test_reconnection_behaviour.py
+++ b/tests/test_reconnection_behaviour.py
@@ -140,6 +140,12 @@ def test_status_request_failure_on_initial_connect_is_non_fatal(
 
     client.connect()
 
+    # The refresh was attempted and failed, not skipped - without this the test
+    # would pass vacuously if connect() stopped refreshing altogether.
+    assert mqtt_client.publish.call_count == 1
+    header, _ = json.loads(mqtt_client.publish.call_args[0][0].payload)
+    assert header["command"] == "comp_query"
+
     assert client._setup_complete is True
     assert client.mqttClient is not None
     # Subscriptions and timers were still set up before the failed refresh.
@@ -247,6 +253,9 @@ def test_status_refresh_skipped_when_setup_torn_down(
     client._request_status_updates_safe()
 
     request_all.assert_not_called()
+    # The early return must not leak the guard, or this one skip would disable
+    # every later refresh for the life of the process.
+    assert not client._status_refresh_lock.locked()
 
 
 def test_status_refresh_failure_releases_the_guard(

--- a/tests/test_reconnection_behaviour.py
+++ b/tests/test_reconnection_behaviour.py
@@ -1,6 +1,7 @@
 """Tests for reconnection behaviour and state persistence."""
 
 import json
+import threading
 from unittest.mock import Mock
 from emerald_hws import EmeraldHWS
 from .conftest import (
@@ -147,6 +148,131 @@ def test_status_request_failure_on_initial_connect_is_non_fatal(
     assert client.health_check_timer is not None
     client.reconnect_timer.cancel()
     client.health_check_timer.cancel()
+
+
+def test_concurrent_status_refresh_collapses_into_one(
+    mock_requests, mock_boto3, mock_mqtt5_client_builder, mock_auth, mock_io, mocker
+):
+    """Test that a refresh starting while another is in flight is skipped.
+
+    connect() releases _connect_lock before refreshing, so a scheduled
+    reconnect or a resume callback can start its own refresh over the top.
+    They cover the same devices, so the second must be dropped rather than
+    doubling the comp_query burst.
+    """
+    _mock_api(mock_requests)
+
+    client = EmeraldHWS("test@example.com", "password")
+    mark_connected(client, mocker)
+    client.connect()
+
+    started = threading.Event()
+    release = threading.Event()
+
+    def blocked_refresh():
+        started.set()
+        assert release.wait(timeout=5)
+
+    request_all = mocker.patch.object(
+        client, "requestAllStatusUpdates", side_effect=blocked_refresh
+    )
+
+    first = threading.Thread(target=client._request_status_updates_safe)
+    first.start()
+    try:
+        assert started.wait(timeout=5), "first refresh never started"
+
+        # Second refresh arrives while the first still holds the lock.
+        client._request_status_updates_safe()
+        assert request_all.call_count == 1
+    finally:
+        release.set()
+        first.join(timeout=5)
+
+    assert request_all.call_count == 1
+
+    # The lock is released afterwards, so a later refresh still runs.
+    client._request_status_updates_safe()
+    assert request_all.call_count == 2
+
+
+def test_nested_status_refresh_does_not_recurse(
+    mock_requests, mock_boto3, mock_mqtt5_client_builder, mock_auth, mock_io, mocker
+):
+    """Test that a refresh reaching back into itself on one thread is a no-op.
+
+    requestAllStatusUpdates fans out to workers that call getFullStatus, which
+    calls connect() if setup was torn down - and connect() ends by refreshing.
+    The guard lock is non-reentrant precisely so that path stops here instead
+    of spawning a nested thread pool per worker.
+    """
+    _mock_api(mock_requests)
+
+    client = EmeraldHWS("test@example.com", "password")
+    mark_connected(client, mocker)
+    client.connect()
+
+    depth = []
+
+    def reenter():
+        depth.append(len(depth) + 1)
+        client._request_status_updates_safe()
+
+    mocker.patch.object(client, "requestAllStatusUpdates", side_effect=reenter)
+
+    client._request_status_updates_safe()
+
+    assert depth == [1], f"refresh recursed {len(depth)} levels deep"
+
+
+def test_status_refresh_skipped_when_setup_torn_down(
+    mock_requests, mock_boto3, mock_mqtt5_client_builder, mock_auth, mock_io, mocker
+):
+    """Test that a refresh is skipped if disconnect() lands underneath it.
+
+    connect() refreshes outside _connect_lock, so disconnect() can null the
+    client in between. Asking over a dead client is pointless, and letting it
+    through would have getFullStatus call connect() and stand up a competing
+    connection.
+    """
+    _mock_api(mock_requests)
+
+    client = EmeraldHWS("test@example.com", "password")
+    mark_connected(client, mocker)
+    client.connect()
+
+    request_all = mocker.patch.object(client, "requestAllStatusUpdates")
+
+    client.disconnect()
+    client._request_status_updates_safe()
+
+    request_all.assert_not_called()
+
+
+def test_status_refresh_failure_releases_the_guard(
+    mock_requests, mock_boto3, mock_mqtt5_client_builder, mock_auth, mock_io, mocker
+):
+    """Test that a raising refresh does not wedge the guard lock shut.
+
+    Without the finally, one failed refresh would silently disable every later
+    one for the life of the process.
+    """
+    _mock_api(mock_requests)
+
+    client = EmeraldHWS("test@example.com", "password")
+    mark_connected(client, mocker)
+    client.connect()
+
+    request_all = mocker.patch.object(
+        client,
+        "requestAllStatusUpdates",
+        side_effect=[Exception("Connection lost"), None],
+    )
+
+    client._request_status_updates_safe()
+    client._request_status_updates_safe()
+
+    assert request_all.call_count == 2
 
 
 def test_status_requested_via_mqtt_during_reconnection(


### PR DESCRIPTION
## Summary by Sourcery

Refresh device status via MQTT on initial connect while ensuring refresh operations are safe, non-blocking, and resilient to failures and concurrency edge cases.

New Features:
- Trigger a best-effort MQTT status refresh of all discovered devices immediately after a successful connect to seed client state from live device data rather than REST snapshots.

Enhancements:
- Introduce a non-blocking guard lock and helper context manager to prevent overlapping or recursive status refreshes and to ensure the lock is always released.
- Refine status refresh logic to skip runs when MQTT setup is incomplete or torn down, and to log detailed warnings with traceback on refresh failures without impacting client usability.

Tests:
- Add comprehensive tests covering initial-connect status refresh behaviour, redundant connects, failure handling, concurrent and nested refresh scenarios, and refresh behaviour when setup is torn down.
- Update existing control and connection gating tests to account for the startup comp_query burst, adding a helper to clear those publishes and new assertions that distinguish seeding queries from control messages.